### PR TITLE
Refactor/#202/exclude current item in wpid filter

### DIFF
--- a/src/pages/partDetails/Hierarchy/index.tsx
+++ b/src/pages/partDetails/Hierarchy/index.tsx
@@ -1,19 +1,19 @@
-import React, { useContext, useState } from 'react'
-import Select from 'react-select'
-import { useGetItemsInfinite } from '../../../services/hooks/Items/useGetItemsInfinite'
-import { useDebounce } from 'usehooks-ts'
-import { Item } from '../../../services/apiTypes'
+import EditIcon from '@mui/icons-material/Edit'
 import { Box, ClickAwayListener } from '@mui/material'
-import { Edit, LabelContainer } from '../PartInfo/styles'
-import { useUpdateItem } from '../../../services/hooks/Items/useUpdateItem'
-import UmAppContext from '../../../contexts/UmAppContext'
+import { useContext, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { useRemoveParentIdFromItem } from '../../../services/hooks/Items/useRemoveParentIdFromItem'
+import Select from 'react-select'
+import { useDebounce } from 'usehooks-ts'
+import UmAppContext from '../../../contexts/UmAppContext'
+import { Item } from '../../../services/apiTypes'
 import {
     AddChildItemIds,
     useAddChildItemToParent,
 } from '../../../services/hooks/Items/useAddChildItemToParent'
-import EditIcon from '@mui/icons-material/Edit'
+import { useGetItemsInfinite } from '../../../services/hooks/Items/useGetItemsInfinite'
+import { useRemoveParentIdFromItem } from '../../../services/hooks/Items/useRemoveParentIdFromItem'
+import { useUpdateItem } from '../../../services/hooks/Items/useUpdateItem'
+import { Edit, LabelContainer } from '../PartInfo/styles'
 
 import {
     AccessibleButtonWrapper,
@@ -23,6 +23,7 @@ import {
     CustomRemoveIcon,
     FlexContainer,
     LinkElement,
+    ParentContainer,
 } from './styles'
 
 export const Hierarchy = ({ item }: { item: Item }) => {
@@ -46,7 +47,11 @@ export const Hierarchy = ({ item }: { item: Item }) => {
 
     const filteredWpIds = data?.pages
         .flatMap((el) => el)
-        .filter((el) => el.wpId?.toLowerCase().includes(debouncedSearchTerm.toLowerCase()) ?? false)
+        .filter(
+            (el) =>
+                el.wpId?.toLowerCase().includes(debouncedSearchTerm.toLowerCase()) &&
+                el.wpId !== item.wpId
+        )
         .map((el) => ({ label: el.wpId, value: el }))
 
     const handleBlur = () => {
@@ -136,43 +141,46 @@ export const Hierarchy = ({ item }: { item: Item }) => {
 
     return (
         <div>
-            <ClickAwayListener onClickAway={clickAwayHandlerParent}>
-                <Box>
-                    <LabelContainer>
-                        <label>
-                            <strong>{`This ${item.type} is a part of:`}</strong>
-                        </label>
-                        <Edit onClick={() => setIsOpen((prev) => ({ ...prev, parent: true }))} />
-                    </LabelContainer>
-                    {isOpen.parent && (
-                        <Select
-                            styles={{
-                                control: (provided) => ({
-                                    ...provided,
-                                    maxWidth: '300px',
-                                }),
-                            }}
-                            onInputChange={(value) => setSearchTerm(value)}
-                            onMenuScrollToBottom={() => fetchNextPage()}
-                            options={filteredWpIds}
-                            isLoading={isLoading}
-                            placeholder="Search by wpid..."
-                            onChange={(value) => setSelectedId(value!.value.wpId)}
-                            onBlur={handleBlur}
-                        />
-                    )}
-                    {!isOpen.parent && (
-                        <>
-                            {item.parent && (
-                                <LinkElement onClick={() => navigate(`/${item.parent?.id}`)}>
-                                    {item.parent?.wpId}
-                                </LinkElement>
-                            )}
-
-                        </>
-                    )}
-                </Box>
-            </ClickAwayListener>
+            <ParentContainer>
+                <ClickAwayListener onClickAway={clickAwayHandlerParent}>
+                    <Box>
+                        <LabelContainer>
+                            <label>
+                                <strong>{`This ${item.type} is a part of:`}</strong>
+                            </label>
+                            <Edit
+                                onClick={() => setIsOpen((prev) => ({ ...prev, parent: true }))}
+                            />
+                        </LabelContainer>
+                        {isOpen.parent && (
+                            <Select
+                                styles={{
+                                    control: (provided) => ({
+                                        ...provided,
+                                        maxWidth: '300px',
+                                    }),
+                                }}
+                                onInputChange={(value) => setSearchTerm(value)}
+                                onMenuScrollToBottom={() => fetchNextPage()}
+                                options={filteredWpIds}
+                                isLoading={isLoading}
+                                placeholder="Search by wpid..."
+                                onChange={(value) => setSelectedId(value!.value.wpId)}
+                                onBlur={handleBlur}
+                            />
+                        )}
+                        {!isOpen.parent && (
+                            <>
+                                {item.parent && (
+                                    <LinkElement onClick={() => navigate(`/${item.parent?.id}`)}>
+                                        {item.parent?.wpId}
+                                    </LinkElement>
+                                )}
+                            </>
+                        )}
+                    </Box>
+                </ClickAwayListener>
+            </ParentContainer>
             <ClickAwayListener onClickAway={clickAwayHandlerChild}>
                 <Box>
                     <FlexContainer>

--- a/src/pages/partDetails/Hierarchy/styles.ts
+++ b/src/pages/partDetails/Hierarchy/styles.ts
@@ -3,6 +3,11 @@ import { COLORS } from '../../../style/GlobalStyles'
 import RemoveIcon from '@mui/icons-material/Close'
 import Add from '@mui/icons-material/Add'
 
+
+
+export const ParentContainer = styled.div`
+    margin-bottom: 28px;
+`
 export const AddIcon = styled(Add)<{ disabled: boolean }>`
     color: ${(props) => (props.disabled ? '#ddd' : COLORS.primary)};
     cursor: ${(props) => (props.disabled ? 'not-allowed' : 'pointer')};


### PR DESCRIPTION
## Pull Request Summary

### What is missing from the codebase?
Please briefly describe any missing elements or features in the codebase that this pull request addresses.
- Ensuring the current item is excluded from search results for a more intuitive user experience.


### Rationale for Changes
Explain the reasoning behind the changes made in this pull request. Why were these modifications necessary?
- The changes are aimed at improving the user experience by excluding the current item from the displayed results. Prior to this update, the search results included the current item, which could be confusing for users.


## Changes Made
Please provide a concise overview of the specific changes made in this pull request.
- Improved the wpId filter logic to exclude the current item from the results, ensuring it doesn't display itself.


---
## Checklist

- [x] **Linting**: Have you run the linter to ensure code consistency?
- [x] **Code Formatting**: Is the code formatted according to project standards?
- [x] **Review**: Have you reviewed your own changes to ensure they align with best practices?
