### PR TITLE
228-fix-cards-are-not-clickable-at-search

### DIFF
--- a/src/components/PartCard/PartCard.tsx
+++ b/src/components/PartCard/PartCard.tsx
@@ -12,13 +12,12 @@ const PartCard = ({ part, icon }: Props) => {
     const navigate = useNavigate();
 
     const handleClick = () => {
-        if (location.pathname === '/search' || location.pathname === '/add-part') {
-            navigate(`/${part.id}`);
-        }
+        if (location.pathname.includes('makelist')) return;
+        navigate(`/${part.id}`);
     };
 
     const cursorStyle =
-        location.pathname === '/search' || location.pathname === '/add-part'
+        location.pathname.includes('/search') || location.pathname.includes('/add-part')
             ? 'pointer'
             : undefined;
 


### PR DESCRIPTION
## Pull Request Summary

### What is missing from the codebase?
bug with the card component not being clickeble if the route is search/searchparams

### Changes made in this pull request:

- added include instead of "===", so it will work at search/searchparams page as well,
- added a return statment for (makelist) page, so the card is not cliceble if the route includes makelist

## Checklist

-   [x] **Linting**: Have you run the linter to ensure code consistency?
-   [x] **Code Formatting**: Is the code formatted according to project standards?
-   [x] **Review**: Have you reviewed your own changes to ensure they align with best practices?
