### PR TITLE
252 fix warning have correct color depending on unique wpid

### DIFF
--- a/src/components/AddPartFormFields/WpId/WpId.tsx
+++ b/src/components/AddPartFormFields/WpId/WpId.tsx
@@ -42,7 +42,7 @@ export const WpId = () => {
                 autoComplete="off"
                 value={wpId}
                 onChange={(e) => setWpId(e.target.value)}
-                isUnique={isUnique}
+                $isUnique={isUnique}
             />
             {isLoading && <p>Checking...</p>}
             {wpId && (
@@ -51,7 +51,7 @@ export const WpId = () => {
                         <StyledParagraph>WellPartner ID is unique!</StyledParagraph>
                     )}
                     {isUnique === false && (
-                        <StyledParagraph isUnique={isUnique}>
+                        <StyledParagraph $isUnique={isUnique}>
                             WellPartner ID is not unique. Please choose a different one.
                         </StyledParagraph>
                     )}

--- a/src/components/AddPartFormFields/WpId/WpId.tsx
+++ b/src/components/AddPartFormFields/WpId/WpId.tsx
@@ -42,7 +42,7 @@ export const WpId = () => {
                 autoComplete="off"
                 value={wpId}
                 onChange={(e) => setWpId(e.target.value)}
-                isUnique={isUnique?.toString()}
+                isUnique={isUnique}
             />
             {isLoading && <p>Checking...</p>}
             {wpId && (
@@ -51,7 +51,7 @@ export const WpId = () => {
                         <StyledParagraph>WellPartner ID is unique!</StyledParagraph>
                     )}
                     {isUnique === false && (
-                        <StyledParagraph>
+                        <StyledParagraph isUnique={isUnique}>
                             WellPartner ID is not unique. Please choose a different one.
                         </StyledParagraph>
                     )}

--- a/src/components/AddPartFormFields/WpId/WpId.tsx
+++ b/src/components/AddPartFormFields/WpId/WpId.tsx
@@ -25,7 +25,7 @@ export const WpId = () => {
         <StyledDiv>
             <StyledInputWrap>
                 <StyledIconContainer>
-                    <label htmlFor="WellPartner Id">WellPartner ID </label>{' '}
+                    <label htmlFor="WellPartner Id">WellPartner ID </label>
                     <ToolTip content="Specify a unique WellPartner ID">
                         <FaRegQuestionCircleIcon />
                     </ToolTip>

--- a/src/components/AddPartFormFields/WpId/styles.ts
+++ b/src/components/AddPartFormFields/WpId/styles.ts
@@ -2,7 +2,7 @@ import { styled } from 'styled-components';
 import { COLORS } from '../../../style/GlobalStyles.ts';
 
 interface StyledInputProps {
-    isUnique?: boolean;
+    $isUnique?: boolean;
 }
 
 export const StyledInput = styled.input<StyledInputProps>`
@@ -11,11 +11,11 @@ export const StyledInput = styled.input<StyledInputProps>`
         border: none;
         border-radius: 0;
         border-bottom: 1px solid #000;
-        border: ${(props) => (props.isUnique === false ? `1px solid ${COLORS.red}` : null)};
+        border: ${(props) => (props.$isUnique === false ? `1px solid ${COLORS.red}` : null)};
     }
 `;
 
 export const StyledParagraph = styled.p<StyledInputProps>`
-    color: ${(props) => (props.isUnique === false ? COLORS.red : COLORS.green)};
+    color: ${(props) => (props.$isUnique === false ? COLORS.red : COLORS.green)};
     margin-top: 0px;
 `;

--- a/src/components/AddPartFormFields/WpId/styles.ts
+++ b/src/components/AddPartFormFields/WpId/styles.ts
@@ -2,7 +2,7 @@ import { styled } from 'styled-components';
 import { COLORS } from '../../../style/GlobalStyles.ts';
 
 interface StyledInputProps {
-    isUnique?: string | undefined;
+    isUnique?: boolean;
 }
 
 export const StyledInput = styled.input<StyledInputProps>`
@@ -11,11 +11,11 @@ export const StyledInput = styled.input<StyledInputProps>`
         border: none;
         border-radius: 0;
         border-bottom: 1px solid #000;
-        border: ${(props) => (props.isUnique === 'false' ? '1px solid red' : null)};
+        border: ${(props) => (props.isUnique === false ? `1px solid ${COLORS.red}` : null)};
     }
 `;
 
 export const StyledParagraph = styled.p<StyledInputProps>`
-    color: ${(props) => (props.isUnique === 'false' ? COLORS.red : COLORS.green)};
+    color: ${(props) => (props.isUnique === false ? COLORS.red : COLORS.green)};
     margin-top: 0px;
 `;

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -299,8 +299,7 @@ const apiService = () => {
         return await postByFetch(`Item/RemoveParentId?itemId=${itemId}`);
     };
 
-    const isWpIdUnique = async (id: string) => {
-        if (!id) return;
+    const isWpIdUnique = async (id: string): Promise<boolean> => {
         return await getByFetch(`Item/IsWpIdUnique/${id}`);
     };
 


### PR DESCRIPTION
## Pull Request Summary

### What is missing from the codebase?

Currently, warning text is green when wp id is not unique

### Changes made in this pull request:

- fixed warning text, now warning text is red when its not a unique wp id

## Checklist

-   [x] **Review**: Have you reviewed your own changes to ensure they align with best practices?
