### PR TITLE
272 refactor remove border radius on text fields and rearrange fields

### DIFF
--- a/src/components/PartDetails/CommentForm/CommentForm.tsx
+++ b/src/components/PartDetails/CommentForm/CommentForm.tsx
@@ -64,6 +64,7 @@ export const Comments = ({ item }: { item: Item }) => {
                                     fullWidth
                                     onChange={onChange}
                                     variant="filled"
+                                    InputProps={{ sx: { borderRadius: 0 } }}
                                     sx={{
                                         '&::before': {
                                             display: 'none',

--- a/src/pages/partDetails/Log.tsx
+++ b/src/pages/partDetails/Log.tsx
@@ -21,6 +21,7 @@ export const Log = ({ item }: { item: Item }) => {
         <>
             <h4>Log</h4>
             <ScrollTextField
+                InputProps={{ sx: { borderRadius: 0 } }}
                 value={formattedLogEntries.length < 1 ? 'No log entries' : formattedLogEntries}
                 multiline
                 variant="filled"

--- a/src/pages/partDetails/partInfo/PartInfo.tsx
+++ b/src/pages/partDetails/partInfo/PartInfo.tsx
@@ -139,6 +139,46 @@ const PartInfo = ({ item, isLoading }: PartInfoProps) => {
         <PartInfoForm>
             <Container>
                 <SelectField
+                    placeholder="Select location..."
+                    fieldName="LOCATION"
+                    label="location"
+                    options={convertOptionsToSelectFormat(locations)}
+                    onBlur={() => handleBlurItemProperties('locationId', 'location')}
+                />
+
+                <SelectField
+                    placeholder="Select vendor..."
+                    fieldName="VENDOR"
+                    label="vendor"
+                    options={convertOptionsToSelectFormat(vendors)}
+                    onBlur={() => handleBlurItemProperties('vendorId', 'vendor')}
+                />
+
+                <EditableField
+                    fieldName="S/N"
+                    label="serialNumber"
+                    onBlur={() => handleBlurItemProperties('serialNumber', 'serialNumber')}
+                />
+
+                <EditableField
+                    fieldName="WPID"
+                    label="wpId"
+                    onBlur={() => {
+                        if (isUniqueWpId === true) {
+                            setValue('wpId', debouncedWpId);
+
+                            handleBlurItemProperties('wpId', 'wpId');
+                        }
+                    }}
+                    isUnique={isUniqueWpId}
+                    loading={isLoadingUniqueWpId}
+                    onChange={(event) => {
+                        setNewWpId(event.target.value);
+                    }}
+                    value={wpId}
+                />
+
+                <SelectField
                     placeholder="Select type..."
                     fieldName="TYPE"
                     label="itemTemplate.type"
@@ -163,12 +203,15 @@ const PartInfo = ({ item, isLoading }: PartInfoProps) => {
                     }
                 />
 
-                <SelectField
-                    placeholder="Select location..."
-                    fieldName="LOCATION"
-                    label="location"
-                    options={convertOptionsToSelectFormat(locations)}
-                    onBlur={() => handleBlurItemProperties('locationId', 'location')}
+                <EditableField
+                    fieldName="P/N"
+                    label="itemTemplate.productNumber"
+                    onBlur={() =>
+                        handleBlurItemTemplateProperties(
+                            'productNumber',
+                            'itemTemplate.productNumber' as keyof PartInfoSchema
+                        )
+                    }
                 />
 
                 <CreatedByContainer>
@@ -181,47 +224,6 @@ const PartInfo = ({ item, isLoading }: PartInfoProps) => {
                             : `${item.createdBy.firstName} ${item.createdBy.lastName}`}
                     </p>
                 </CreatedByContainer>
-                <EditableField
-                    fieldName="S/N"
-                    label="serialNumber"
-                    onBlur={() => handleBlurItemProperties('serialNumber', 'serialNumber')}
-                />
-                <EditableField
-                    fieldName="P/N"
-                    label="itemTemplate.productNumber"
-                    onBlur={() =>
-                        handleBlurItemTemplateProperties(
-                            'productNumber',
-                            'itemTemplate.productNumber' as keyof PartInfoSchema
-                        )
-                    }
-                />
-
-                <SelectField
-                    placeholder="Select vendor..."
-                    fieldName="VENDOR"
-                    label="vendor"
-                    options={convertOptionsToSelectFormat(vendors)}
-                    onBlur={() => handleBlurItemProperties('vendorId', 'vendor')}
-                />
-
-                <EditableField
-                    fieldName="WPID"
-                    label="wpId"
-                    onBlur={() => {
-                        if (isUniqueWpId === true) {
-                            setValue('wpId', debouncedWpId);
-
-                            handleBlurItemProperties('wpId', 'wpId');
-                        }
-                    }}
-                    isUnique={isUniqueWpId}
-                    loading={isLoadingUniqueWpId}
-                    onChange={(event) => {
-                        setNewWpId(event.target.value);
-                    }}
-                    value={wpId}
-                />
             </Container>
             <EditableField
                 fieldName="DESCRIPTION"


### PR DESCRIPTION
## Pull Request Summary

### What is missing from the codebase?

Currently, there are border radius on text fields, which there should not be.
The fields on part info is arranged wrong, should be item properties on one row and item template properties on separate row.

### Changes made in this pull request:

- removed border radius on Log and Comment text fields
- rearranged input fields, now item properties are on top row and templates are on bottom row

## Checklist

-   [x] **Review**: Have you reviewed your own changes to ensure they align with best practices?
