### PR TITLE
refactor: snackbar from hook to component

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,9 +9,9 @@ import {
     createRoutesFromElements,
 } from 'react-router-dom';
 import ResponsiveRoute from './components/ResponsiveRoute/ResponsiveRoute.tsx';
+import SnackBar from './components/Snackbar/Snackbar.tsx';
 import ResponsiveAppBar from './components/TopBar/ResponsiveAppBar.tsx';
 import { AppContextProvider } from './contexts/AppContext';
-import { useSnackBar } from './hooks/useSnackbar.tsx';
 import { useWindowDimensions } from './hooks/useWindowDimensions.ts';
 import AddItem from './pages/addItem/Index';
 import { AddItemForm } from './pages/addItem/addItemForm/AddItemForm.tsx';
@@ -38,7 +38,6 @@ function App() {
     const isAuthenticated = useIsAuthenticated();
     const queryClient = new QueryClient();
     const { width } = useWindowDimensions();
-    const { snackbar } = useSnackBar();
 
     const router = createBrowserRouter(
         createRoutesFromElements(
@@ -86,7 +85,7 @@ function App() {
                     {isAuthenticated && (
                         <AppContextProvider>
                             <GlobalStyles width={width} />
-                            {snackbar}
+                            <SnackBar />
                             <RouterProvider router={router} />
                         </AppContextProvider>
                     )}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,7 +9,7 @@ import {
     createRoutesFromElements,
 } from 'react-router-dom';
 import ResponsiveRoute from './components/ResponsiveRoute/ResponsiveRoute.tsx';
-import SnackBar from './components/Snackbar/Snackbar.tsx';
+import { Snackbar } from './components/Snackbar/Snackbar.tsx';
 import ResponsiveAppBar from './components/TopBar/ResponsiveAppBar.tsx';
 import { AppContextProvider } from './contexts/AppContext';
 import { useWindowDimensions } from './hooks/useWindowDimensions.ts';
@@ -85,7 +85,7 @@ function App() {
                     {isAuthenticated && (
                         <AppContextProvider>
                             <GlobalStyles width={width} />
-                            <SnackBar />
+                            <Snackbar />
                             <RouterProvider router={router} />
                         </AppContextProvider>
                     )}

--- a/src/components/Snackbar/Snackbar.stories.tsx
+++ b/src/components/Snackbar/Snackbar.stories.tsx
@@ -1,11 +1,11 @@
 import { Meta, StoryObj } from '@storybook/react';
-import { useSnackBar } from './useSnackbar';
+import SnackBar from './Snackbar';
 
 const meta = {
-    title: 'hooks/useSnackbar',
-    hook: useSnackBar,
+    title: 'Components/Snackbar',
+    component: SnackBar,
     tags: ['autodocs'],
-} as Meta<typeof useSnackBar>;
+} as Meta<typeof SnackBar>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;

--- a/src/components/Snackbar/Snackbar.stories.tsx
+++ b/src/components/Snackbar/Snackbar.stories.tsx
@@ -1,11 +1,11 @@
 import { Meta, StoryObj } from '@storybook/react';
-import SnackBar from './Snackbar';
+import { Snackbar } from './Snackbar';
 
 const meta = {
     title: 'Components/Snackbar',
-    component: SnackBar,
+    component: Snackbar,
     tags: ['autodocs'],
-} as Meta<typeof SnackBar>;
+} as Meta<typeof Snackbar>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;

--- a/src/components/Snackbar/Snackbar.tsx
+++ b/src/components/Snackbar/Snackbar.tsx
@@ -26,5 +26,3 @@ export const Snackbar: React.FC<SnackbarProps> = () => {
         </MuiSnackbar>
     );
 };
-
-export default SnackBar;

--- a/src/components/Snackbar/Snackbar.tsx
+++ b/src/components/Snackbar/Snackbar.tsx
@@ -1,8 +1,8 @@
-import { Alert, Snackbar } from '@mui/material';
+import { Alert, Snackbar, SnackbarProps } from '@mui/material';
 import { useContext } from 'react';
-import AppContext from '../contexts/AppContext';
+import AppContext from '../../contexts/AppContext';
 
-export const useSnackBar = () => {
+const SnackBar: React.FC<SnackbarProps> = () => {
     const {
         showSnackbar,
         snackbarText,
@@ -12,7 +12,7 @@ export const useSnackBar = () => {
         setSnackbarSeverity,
     } = useContext(AppContext);
 
-    const snackbar = (
+    return (
         <Snackbar
             autoHideDuration={3000}
             onClose={() => {
@@ -25,6 +25,6 @@ export const useSnackBar = () => {
             <Alert severity={snackbarSeverity}>{snackbarText}</Alert>
         </Snackbar>
     );
-
-    return { snackbar };
 };
+
+export default SnackBar;

--- a/src/components/Snackbar/Snackbar.tsx
+++ b/src/components/Snackbar/Snackbar.tsx
@@ -1,8 +1,8 @@
-import { Alert, Snackbar, SnackbarProps } from '@mui/material';
+import { Alert, Snackbar as MuiSnackbar, SnackbarProps } from '@mui/material';
 import { useContext } from 'react';
 import AppContext from '../../contexts/AppContext';
 
-const SnackBar: React.FC<SnackbarProps> = () => {
+export const Snackbar: React.FC<SnackbarProps> = () => {
     const {
         showSnackbar,
         snackbarText,
@@ -13,7 +13,7 @@ const SnackBar: React.FC<SnackbarProps> = () => {
     } = useContext(AppContext);
 
     return (
-        <Snackbar
+        <MuiSnackbar
             autoHideDuration={3000}
             onClose={() => {
                 setShowSnackbar(false);
@@ -23,8 +23,6 @@ const SnackBar: React.FC<SnackbarProps> = () => {
             open={showSnackbar}
         >
             <Alert severity={snackbarSeverity}>{snackbarText}</Alert>
-        </Snackbar>
+        </MuiSnackbar>
     );
 };
-
-export default SnackBar;

--- a/src/contexts/AppContext.tsx
+++ b/src/contexts/AppContext.tsx
@@ -6,7 +6,7 @@ import { createContext, useEffect, useState } from 'react';
 import { GlobalSpinner } from '../components/GlobalSpinner/GlobalSpinner';
 import apiService from '../services/api';
 import { ApiStatus, User } from '../services/apiTypes';
-import { AzureUserInfo, AppContextType } from './types';
+import { AppContextType, AzureUserInfo } from './types';
 
 const AppContext = createContext<AppContextType>({} as AppContextType);
 
@@ -114,7 +114,6 @@ export function AppContextProvider({ children }: { children: React.ReactNode }) 
                 value={{
                     showSnackbar,
                     setShowSnackbar,
-
                     snackbarText,
                     setSnackbarText,
                     snackbarSeverity,

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,2 +1,2 @@
+export * from '../components/Snackbar/Snackbar';
 export * from './useWindowDimensions';
-export * from './useSnackbar';

--- a/src/pages/addItem/hooks/itemValidator.ts
+++ b/src/pages/addItem/hooks/itemValidator.ts
@@ -19,10 +19,10 @@ export const itemSchema = z.object({
     comment: z.string().nullish(),
     isBatch: z.boolean(),
     preCheck: z.object({
-        check: z.boolean().refine((value) => value),
+        check: z.boolean().refine((value) => value, 'Required '),
         comment: z.string(),
     }),
-    documentation: z.boolean().refine((value) => value),
+    documentation: z.boolean().refine((value) => value, 'Required'),
     documents: z
         .array(
             z.object({

--- a/src/pages/itemDetails/itemInfo/ItemInfo.tsx
+++ b/src/pages/itemDetails/itemInfo/ItemInfo.tsx
@@ -4,10 +4,8 @@ import { useFormContext } from 'react-hook-form';
 import { useDebounce } from 'usehooks-ts';
 import { GlobalSpinner } from '../../../components/GlobalSpinner/GlobalSpinner';
 import AppContext from '../../../contexts/AppContext';
-import { useSnackBar } from '../../../hooks';
 import type { Item } from '../../../services/apiTypes';
 import { useGetCategories } from '../../../services/hooks/category/useGetCategories';
-
 import { useIsWpIdUnique } from '../../../services/hooks/items/useIsWpIdUnique';
 import { useUpdateItem } from '../../../services/hooks/items/useUpdateItem';
 import { useGetLocations } from '../../../services/hooks/locations/useGetLocations';
@@ -43,7 +41,6 @@ const ItemInfo = ({ item, isLoading }: ItemInfoProps) => {
     const { data: vendors = [], isLoading: isLoadingVendors } = useGetVendors();
     const { data: locations = [], isLoading: isLoadingLocations } = useGetLocations();
     const { data: categories = [], isLoading: isLoadingCategories } = useGetCategories();
-    const { snackbar } = useSnackBar();
     const { mutate } = useUpdateItem(item?.id, currentUser!.id);
     const { data: itemTemplateData } = useGetItemTemplateById(item.itemTemplate.id);
     const { mutate: mutateItemTemplate } = useUpdateItemTemplate(item.itemTemplate.id);
@@ -241,8 +238,6 @@ const ItemInfo = ({ item, isLoading }: ItemInfoProps) => {
                     )
                 }
             />
-
-            {snackbar}
         </ItemInfoForm>
     );
 };

--- a/src/pages/list/MakeList.tsx
+++ b/src/pages/list/MakeList.tsx
@@ -7,7 +7,6 @@ import { GlobalSpinner } from '../../components/GlobalSpinner/GlobalSpinner.tsx'
 import { ListCard } from '../../components/ListCard/ListCard.tsx';
 import SearchBar from '../../components/SearchBar/SearchBar.tsx';
 import AppContext from '../../contexts/AppContext.tsx';
-import { useSnackBar } from '../../hooks/useSnackbar.tsx';
 import { Item, List } from '../../services/apiTypes.ts';
 import { useAddList } from '../../services/hooks/list/useAddList.tsx';
 import { useGetListsByUserId } from '../../services/hooks/list/useGetListsByUserId.tsx';
@@ -24,7 +23,7 @@ const MakeList = () => {
     const { data: lists = [], isLoading } = useGetListsByUserId(currentUser!.id);
 
     const { mutate } = useAddList();
-    const { snackbar } = useSnackBar();
+
     useEffect(() => {
         setSearchTerm((prev) => searchParam ?? prev);
     }, [searchParam]);
@@ -94,7 +93,6 @@ const MakeList = () => {
                     ))}
                 </FlexWrapper>
             </SearchContainer>
-            {snackbar}
         </>
     );
 };

--- a/src/pages/list/MakeList.tsx
+++ b/src/pages/list/MakeList.tsx
@@ -6,7 +6,6 @@ import { CustomDialog } from '../../components/CustomDialog/CustomDialog.tsx';
 import { GlobalSpinner } from '../../components/GlobalSpinner/GlobalSpinner.tsx';
 import { ListCard } from '../../components/ListCard/ListCard.tsx';
 import SearchBar from '../../components/SearchBar/SearchBar.tsx';
-import { useSnackBar } from '../../components/Snackbar/Snackbar.tsx';
 import AppContext from '../../contexts/AppContext.tsx';
 import { Item, List } from '../../services/apiTypes.ts';
 import { useAddList } from '../../services/hooks/list/useAddList.tsx';

--- a/src/pages/list/MakeList.tsx
+++ b/src/pages/list/MakeList.tsx
@@ -6,6 +6,7 @@ import { CustomDialog } from '../../components/CustomDialog/CustomDialog.tsx';
 import { GlobalSpinner } from '../../components/GlobalSpinner/GlobalSpinner.tsx';
 import { ListCard } from '../../components/ListCard/ListCard.tsx';
 import SearchBar from '../../components/SearchBar/SearchBar.tsx';
+import { useSnackBar } from '../../components/Snackbar/Snackbar.tsx';
 import AppContext from '../../contexts/AppContext.tsx';
 import { Item, List } from '../../services/apiTypes.ts';
 import { useAddList } from '../../services/hooks/list/useAddList.tsx';

--- a/src/pages/listDetails/ListDetails.tsx
+++ b/src/pages/listDetails/ListDetails.tsx
@@ -2,18 +2,16 @@ import { useContext, useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { useDebounce } from 'usehooks-ts';
 import { Button } from '../../components/Button/Button.tsx';
+import { GlobalSpinner } from '../../components/GlobalSpinner/GlobalSpinner.tsx';
 import ItemCard from '../../components/ItemCard/ItemCard.tsx';
 import SearchResultCardCompact from '../../components/ItemCard/SearchInfoCompact/SearchInfoCompact.tsx';
 import SearchBar from '../../components/SearchBar/SearchBar.tsx';
 import AppContext from '../../contexts/AppContext.tsx';
-import { useSnackBar, useWindowDimensions } from '../../hooks';
+import { useWindowDimensions } from '../../hooks';
 import { Item, UpdateList } from '../../services/apiTypes.ts';
-import { useGetListById } from '../../services/hooks/list/useGetListById.tsx';
-
-import { GlobalSpinner } from '../../components/GlobalSpinner/GlobalSpinner.tsx';
-
 import useExportToExcel from '../../services/hooks/export/useExportToExcel.ts';
 import { useGetItemsInfinite } from '../../services/hooks/items/useGetItemsInfinite.tsx';
+import { useGetListById } from '../../services/hooks/list/useGetListById.tsx';
 import { useUpdateList } from '../../services/hooks/list/useUpdateList.tsx';
 import { Container } from '../search/styles.ts';
 import { ListHeader } from './ListHeader.tsx';
@@ -35,7 +33,6 @@ const ListDetails = () => {
     const { width } = useWindowDimensions();
     const navigate = useNavigate();
     const { data: list, isFetching } = useGetListById(listId!);
-    const { snackbar } = useSnackBar();
     const { data: items, isLoading, fetchNextPage } = useGetItemsInfinite(debouncedSearchTerm);
     const { exportToExcel } = useExportToExcel();
 
@@ -143,7 +140,7 @@ const ListDetails = () => {
                         </FlexWrapper>
                     </>
                 ) : null}
-                {snackbar}
+
                 {(isLoading || isFetching) && <GlobalSpinner />}
             </SearchContainerList>
         </>

--- a/src/pages/listDetails/ListHeader.tsx
+++ b/src/pages/listDetails/ListHeader.tsx
@@ -5,7 +5,7 @@ import { Chip, TextField } from '@mui/material';
 import { useNavigate } from 'react-router-dom';
 import { CustomDialog } from '../../components/CustomDialog/CustomDialog';
 import AppContext from '../../contexts/AppContext';
-import { useSnackBar, useWindowDimensions } from '../../hooks';
+import { useWindowDimensions } from '../../hooks';
 import { List, UpdateList } from '../../services/apiTypes';
 import { useDeleteList } from '../../services/hooks/list/useDeleteList';
 import { useUpdateList } from '../../services/hooks/list/useUpdateList';
@@ -34,7 +34,6 @@ export const ListHeader = ({ list }: Props) => {
     const [openEdit, setOpenEdit] = useState(false);
     const { mutate } = useDeleteList();
     const { mutate: updateList } = useUpdateList(list.id);
-    const { snackbar } = useSnackBar();
 
     const handleOpen = (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
         e.stopPropagation();
@@ -157,7 +156,6 @@ export const ListHeader = ({ list }: Props) => {
                     variant="standard"
                 />
             </CustomDialog>
-            {snackbar}
         </>
     );
 };

--- a/src/pages/listDetails/phone/AddMore.tsx
+++ b/src/pages/listDetails/phone/AddMore.tsx
@@ -5,13 +5,11 @@ import { GlobalSpinner } from '../../../components/GlobalSpinner/GlobalSpinner';
 import SearchResultCardCompact from '../../../components/ItemCard/SearchInfoCompact/SearchInfoCompact';
 
 import SearchBar from '../../../components/SearchBar/SearchBar';
-import { useSnackBar } from '../../../hooks';
+import { useGetItemsInfinite } from '../../../services/hooks/items/useGetItemsInfinite';
 import { useGetListById } from '../../../services/hooks/list/useGetListById';
 import { PhoneContainer, PhoneListTitle } from './styles';
-import { useGetItemsInfinite } from '../../../services/hooks/items/useGetItemsInfinite';
 
 export const AddMoreCompact = () => {
-    const { snackbar } = useSnackBar();
     const [searchTerm, setSearchTerm] = useState('');
 
     const debouncedSearchTerm = useDebounce(searchTerm, 500);
@@ -68,7 +66,7 @@ export const AddMoreCompact = () => {
                     ))
                 )}
             </PhoneContainer>
-            {snackbar}
+
             {(isLoading || isFetching) && <GlobalSpinner />}
         </>
     );

--- a/src/pages/listDetails/phone/list/PhoneList.tsx
+++ b/src/pages/listDetails/phone/list/PhoneList.tsx
@@ -7,7 +7,6 @@ import { GlobalSpinner } from '../../../../components/GlobalSpinner/GlobalSpinne
 import SearchResultCardCompact from '../../../../components/ItemCard/SearchInfoCompact/SearchInfoCompact';
 
 import AppContext from '../../../../contexts/AppContext';
-import { useSnackBar } from '../../../../hooks';
 import { Item, List, UpdateList } from '../../../../services/apiTypes';
 import { useGetItemsInfinite } from '../../../../services/hooks/items/useGetItemsInfinite';
 import { useGetListById } from '../../../../services/hooks/list/useGetListById';
@@ -24,12 +23,8 @@ export const PhoneList = ({ list }: Props) => {
     const { listId } = useParams();
     const debouncedSearchTerm = useDebounce(searchTerm, 500);
     const { mutate: updateList } = useUpdateList(listId!);
-
     const { isLoading } = useGetItemsInfinite(debouncedSearchTerm);
-
     const { isFetching } = useGetListById(listId!);
-
-    const { snackbar } = useSnackBar();
     const navigate = useNavigate();
     const handleSave = () => {
         const save: UpdateList = { id: list.id, title: list.title };
@@ -71,7 +66,7 @@ export const PhoneList = ({ list }: Props) => {
                             </Button>
                         </ButtonWrapCompact>
                     </FlexWrapperCompact>
-                    {snackbar}
+
                     {(isLoading || isFetching) && <GlobalSpinner />}
                 </>
             )}


### PR DESCRIPTION
## Pull Request Summary

### What is missing from the codebase?

Currently,  the old snackbar was a hook that returned an object, better to make it to a functional component and move it to the component folder.


### Changes made in this pull request:

-  Added a new component `SnackBar` to handle displaying snackbars.
 - Moved the `useSnackBar` hook to the new `SnackBar` component.
 - Updated the import paths for the `SnackBar` component in various files.
 - Updated the validation logic in the `itemValidator.ts` file.


## Checklist

-   [x] **Review**: Have you reviewed your own changes to ensure they align with best practices?






