### PR TITLE
fix: issue with label/option in Autocomplete in category

### DIFF
--- a/src/components/AddItemFormFields/Category/Category.tsx
+++ b/src/components/AddItemFormFields/Category/Category.tsx
@@ -18,16 +18,17 @@ export const Category = () => {
     });
     const selectedTemplate = watch('itemTemplate.id');
     const { data: categories = [] } = useGetCategories();
-    const selectedCategory = categories.find((option) => option.id === value);
 
     const categoryOptions = categories.map((category) => ({
         value: category.id,
         label: category.name,
     }));
 
+    const selectedCategory = categoryOptions.find((option) => option.label === value);
+
     useEffect(() => {
         if (selectedCategory) {
-            setValue('itemTemplate.categoryId', selectedCategory?.id);
+            setValue('itemTemplate.categoryId', selectedCategory?.value);
         }
     }, [selectedCategory]);
 
@@ -51,7 +52,7 @@ export const Category = () => {
                 isOptionEqualToValue={(option, value) => option.value === value.value}
                 size="small"
                 sx={{ width: '100%' }}
-                value={{ value: selectedCategory?.id, label: selectedCategory?.name ?? '' }}
+                value={selectedCategory}
                 renderInput={(params) => (
                     <TextField {...params} label="Categories" variant="outlined" />
                 )}

--- a/src/components/AddItemFormFields/Category/Category.tsx
+++ b/src/components/AddItemFormFields/Category/Category.tsx
@@ -1,12 +1,11 @@
-import { useController, useFormContext } from 'react-hook-form';
-import { FaRegQuestionCircle as FaRegQuestionCircleIcon } from 'react-icons/fa';
-import { useGetCategories } from '../../../services/hooks/category/useGetCategories.tsx';
-import { ToolTip } from '../../ToolTip/ToolTip.tsx';
-
 import { ErrorMessage } from '@hookform/error-message';
 import { Autocomplete, TextField } from '@mui/material';
 import { useEffect } from 'react';
+import { useController, useFormContext } from 'react-hook-form';
+import { FaRegQuestionCircle as FaRegQuestionCircleIcon } from 'react-icons/fa';
 import { ItemSchema } from '../../../pages/addItem/hooks/itemValidator.ts';
+import { useGetCategories } from '../../../services/hooks/category/useGetCategories.tsx';
+import { ToolTip } from '../../ToolTip/ToolTip.tsx';
 import { StyledDiv, StyledErrorP, StyledIconContainer, StyledInputWrap } from '../styles.ts';
 
 export const Category = () => {
@@ -15,7 +14,6 @@ export const Category = () => {
         field: { onChange, value },
     } = useController({
         name: 'itemTemplate.categoryId',
-
         control,
     });
     const selectedTemplate = watch('itemTemplate.id');
@@ -50,6 +48,7 @@ export const Category = () => {
             <Autocomplete
                 options={categoryOptions}
                 disabled={!!selectedTemplate}
+                isOptionEqualToValue={(option, value) => option.value === value.value}
                 size="small"
                 sx={{ width: '100%' }}
                 value={{ value: selectedCategory?.id, label: selectedCategory?.name ?? '' }}


### PR DESCRIPTION
## Pull Request Summary

### What is missing from the codebase?

Currently, the  Mui autocomplete  in Category in addItem page gave the error
`useAutocomplete.js:211 MUI: The value provided to Autocomplete is invalid.
None of the options match with `{"label":""}`.
You can use the `isOptionEqualToValue` prop to customize the equality test.`


### Changes made in this pull request:

- fixed problem with making the options match with the "label"

## Checklist

-   [x] **Review**: Have you reviewed your own changes to ensure they align with best practices?
