### PR TITLE
Fix custom dialog

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,41 +1,38 @@
 import { useIsAuthenticated } from '@azure/msal-react';
+import { ThemeProvider } from '@mui/material';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import {
+    Navigate,
     Route,
     RouterProvider,
     createBrowserRouter,
     createRoutesFromElements,
 } from 'react-router-dom';
-import { Login } from './pages/login/Login.tsx';
-
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import ResponsiveRoute from './components/ResponsiveRoute/ResponsiveRoute.tsx';
+import ResponsiveAppBar from './components/TopBar/ResponsiveAppBar.tsx';
 import { AppContextProvider } from './contexts/AppContext';
+import { useSnackBar } from './hooks/useSnackbar.tsx';
+import { useWindowDimensions } from './hooks/useWindowDimensions.ts';
 import AddItem from './pages/addItem/Index';
+import { AddItemForm } from './pages/addItem/addItemForm/AddItemForm.tsx';
 import BatchForm from './pages/addItem/batch/BatchForm';
 import CheckForm from './pages/addItem/check/CheckForm';
 import Upload from './pages/addItem/documentation/Upload';
 import RecentlyAdded from './pages/addItem/recentlyAdded/RecentlyAdded';
+import Template from './pages/addItem/template/Template.tsx';
+import AddCategory from './pages/admin/category/AddCategory.tsx';
 import Categories from './pages/admin/category/Categories.tsx';
+import AddLocation from './pages/admin/location/AddLocation.tsx';
 import Locations from './pages/admin/location/Locations.tsx';
+import AddVendor from './pages/admin/vendor/AddVendor.tsx';
 import Vendors from './pages/admin/vendor/Vendors.tsx';
 import ItemDetails from './pages/itemDetails/Index';
 import MakeList from './pages/list/MakeList';
 import ListDetails from './pages/listDetails/ListDetails.tsx';
+import Index from './pages/listDetails/phone/Tabs.tsx';
+import { Login } from './pages/login/Login.tsx';
 import Search from './pages/search/Search';
 import GlobalStyles, { globalTheme } from './style/GlobalStyles';
-
-import { Navigate } from 'react-router-dom';
-import ResponsiveRoute from './components/ResponsiveRoute/ResponsiveRoute.tsx';
-import { useSnackBar } from './hooks/useSnackbar.tsx';
-import { useWindowDimensions } from './hooks/useWindowDimensions.ts';
-import { AddItemForm } from './pages/addItem/addItemForm/AddItemForm.tsx';
-import Template from './pages/addItem/template/Template.tsx';
-import AddCategory from './pages/admin/category/AddCategory.tsx';
-import AddLocation from './pages/admin/location/AddLocation.tsx';
-import AddVendor from './pages/admin/vendor/AddVendor.tsx';
-import Index from './pages/listDetails/phone/Tabs.tsx';
-
-import { ThemeProvider } from '@mui/material';
-import ResponsiveAppBar from './components/TopBar/ResponsiveAppBar.tsx';
 
 function App() {
     const isAuthenticated = useIsAuthenticated();

--- a/src/components/CustomDialog/CustomDialog.stories.tsx
+++ b/src/components/CustomDialog/CustomDialog.stories.tsx
@@ -1,5 +1,5 @@
 import { Meta, StoryObj } from '@storybook/react';
-import CustomDialog from './CustomDialog';
+import { CustomDialog } from './CustomDialog';
 import { useEffect, useState } from 'react';
 import { Button } from '@mui/material';
 import { COLORS } from '../../style/GlobalStyles';

--- a/src/components/CustomDialog/CustomDialog.tsx
+++ b/src/components/CustomDialog/CustomDialog.tsx
@@ -37,7 +37,7 @@ const CustomDialog = ({
                         type={type}
                         sx={{ borderRadius: '0' }}
                     >
-                        {cancelButtonText ?? 'CANCEL'}
+                        {cancelButtonText ?? 'Cancel'}
                     </Button>
 
                     <Button
@@ -47,7 +47,7 @@ const CustomDialog = ({
                         type={type}
                         sx={{ borderRadius: '0' }}
                     >
-                        {submitButtonText ?? 'CONFIRM'}
+                        {submitButtonText ?? 'Confirm'}
                     </Button>
                 </DialogActions>
             </Dialog>

--- a/src/components/CustomDialog/CustomDialog.tsx
+++ b/src/components/CustomDialog/CustomDialog.tsx
@@ -12,7 +12,7 @@ interface DialogProps {
     children?: React.ReactNode;
 }
 
-const CustomDialog = ({
+export const CustomDialog = ({
     title,
     submitButtonText,
     cancelButtonText,
@@ -46,5 +46,3 @@ const CustomDialog = ({
         </>
     );
 };
-
-export default CustomDialog;

--- a/src/components/CustomDialog/CustomDialog.tsx
+++ b/src/components/CustomDialog/CustomDialog.tsx
@@ -10,7 +10,6 @@ interface DialogProps {
     isWarning?: boolean;
     onClose?: (e: React.MouseEvent) => void;
     children?: React.ReactNode;
-    type?: 'submit' | 'reset' | 'button' | undefined;
 }
 
 const CustomDialog = ({
@@ -22,7 +21,6 @@ const CustomDialog = ({
     open,
     children,
     onClose,
-    type,
     isWarning,
 }: DialogProps) => {
     return (
@@ -31,12 +29,7 @@ const CustomDialog = ({
                 <DialogTitle>{title}</DialogTitle>
                 {children ? <DialogContent>{children}</DialogContent> : null}
                 <DialogActions>
-                    <Button
-                        variant="text"
-                        onClick={CancelButtonOnClick}
-                        type={type}
-                        sx={{ borderRadius: '0' }}
-                    >
+                    <Button variant="text" onClick={CancelButtonOnClick} sx={{ borderRadius: '0' }}>
                         {cancelButtonText ?? 'Cancel'}
                     </Button>
 
@@ -44,7 +37,6 @@ const CustomDialog = ({
                         variant="contained"
                         color={isWarning ? 'error' : 'primary'}
                         onClick={SubmitButtonOnClick}
-                        type={type}
                         sx={{ borderRadius: '0' }}
                     >
                         {submitButtonText ?? 'Confirm'}

--- a/src/components/ItemCard/SearchInfo/SearchInfo.tsx
+++ b/src/components/ItemCard/SearchInfo/SearchInfo.tsx
@@ -1,16 +1,12 @@
 import { useContext, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
-
+import AppContext from '../../../contexts/AppContext';
 import { MutateItemList } from '../../../services/apiTypes';
-
 import { useAddItemsToList } from '../../../services/hooks/items/useAddItemsToList';
 import { useRemoveItemsFromList } from '../../../services/hooks/items/useRemoveItemsFromList';
-
-import AppContext from '../../../contexts/AppContext';
 import { useGetListById } from '../../../services/hooks/list/useGetListById';
-import CustomDialog from '../../CustomDialog/CustomDialog';
+import { CustomDialog } from '../../CustomDialog/CustomDialog';
 import { StyledAddIcon, StyledInfoIcon, StyledRemoveIcon } from '../../ListCard/styles';
-
 import { ItemCardProps } from '../ItemCard';
 import {
     StyledBox,

--- a/src/components/ItemCard/SearchInfoCompact/SearchInfoCompact.tsx
+++ b/src/components/ItemCard/SearchInfoCompact/SearchInfoCompact.tsx
@@ -13,7 +13,7 @@ import { MutateItemList } from '../../../services/apiTypes.ts';
 import { useAddItemsToList } from '../../../services/hooks/items/useAddItemsToList.tsx';
 import { useRemoveItemsFromList } from '../../../services/hooks/items/useRemoveItemsFromList.tsx';
 import { useGetListById } from '../../../services/hooks/list/useGetListById.tsx';
-import CustomDialog from '../../CustomDialog/CustomDialog.tsx';
+import { CustomDialog } from '../../CustomDialog/CustomDialog.tsx';
 import { StyledAddIcon, StyledRemoveIcon } from '../../ListCard/styles.ts';
 import { ItemCardProps } from '../ItemCard.tsx';
 import {

--- a/src/components/ListCard/ListCard.tsx
+++ b/src/components/ListCard/ListCard.tsx
@@ -4,14 +4,14 @@ import { useNavigate } from 'react-router-dom';
 import { List } from '../../services/apiTypes.ts';
 
 import { useDeleteList } from '../../services/hooks/list/useDeleteList.tsx';
-import CustomDialog from '../CustomDialog/CustomDialog.tsx';
+import { CustomDialog } from '../CustomDialog/CustomDialog.tsx';
 import { StyledDeleteIcon, StyledListWrapper, StyledTitle } from './styles.ts';
 
 type Props = {
     item: List;
 };
 
-const ListCard = ({ item }: Props) => {
+export const ListCard = ({ item }: Props) => {
     const navigate = useNavigate();
     const { mutate } = useDeleteList();
     const [open, setOpen] = useState(false);
@@ -61,4 +61,4 @@ const ListCard = ({ item }: Props) => {
     );
 };
 
-export default ListCard;
+// export default ListCard;

--- a/src/pages/itemDetails/Index.tsx
+++ b/src/pages/itemDetails/Index.tsx
@@ -1,20 +1,20 @@
 import { Breadcrumbs, Button } from '@mui/material';
+import { useState } from 'react';
 import { FormProvider } from 'react-hook-form';
 import { useNavigate, useParams } from 'react-router-dom';
+import { CustomDialog } from '../../components/CustomDialog/CustomDialog';
+import { Comments } from '../../components/ItemDetails/CommentForm/CommentForm';
 import { ExampleUpload } from '../../components/Upload/Upload';
 import UploadMobile from '../../components/Upload/UploadMobile/UploadMobile';
 import { useWindowDimensions } from '../../hooks';
+import { useDeleteItemById } from '../../services/hooks/items/useDeleteItemById';
 import { useGetItemById } from '../../services/hooks/items/useGetItemById';
+import { ButtonContainer } from '../addItem/styles';
 import { Log } from './Log';
-import { Comments } from '../../components/ItemDetails/CommentForm/CommentForm';
 import { Hierarchy } from './hierarchy';
 import ItemInfo from './itemInfo/ItemInfo';
 import { useUpdateItemForm } from './itemInfo/hooks/useUpdateItemForm';
 import { BreadcrumbLink, BreadcrumbsMargin, StyledContainerDiv } from './styles';
-import { ButtonContainer } from '../addItem/styles';
-import { useDeleteItemById } from '../../services/hooks/items/useDeleteItemById';
-import { useState } from 'react';
-import CustomDialog from '../../components/CustomDialog/CustomDialog';
 
 const ItemDetails = () => {
     const { id } = useParams() as { id: string };

--- a/src/pages/list/MakeList.tsx
+++ b/src/pages/list/MakeList.tsx
@@ -2,14 +2,13 @@ import TextField from '@mui/material/TextField';
 import { useContext, useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { Button } from '../../components/Button/Button.tsx';
-import CustomDialog from '../../components/CustomDialog/CustomDialog.tsx';
-import ListCard from '../../components/ListCard/ListCard.tsx';
+import { CustomDialog } from '../../components/CustomDialog/CustomDialog.tsx';
+import { GlobalSpinner } from '../../components/GlobalSpinner/GlobalSpinner.tsx';
+import { ListCard } from '../../components/ListCard/ListCard.tsx';
 import SearchBar from '../../components/SearchBar/SearchBar.tsx';
 import AppContext from '../../contexts/AppContext.tsx';
 import { useSnackBar } from '../../hooks/useSnackbar.tsx';
 import { Item, List } from '../../services/apiTypes.ts';
-
-import { GlobalSpinner } from '../../components/GlobalSpinner/GlobalSpinner.tsx';
 import { useAddList } from '../../services/hooks/list/useAddList.tsx';
 import { useGetListsByUserId } from '../../services/hooks/list/useGetListsByUserId.tsx';
 import { SearchContainer } from '../search/styles.ts';

--- a/src/pages/listDetails/ListHeader.tsx
+++ b/src/pages/listDetails/ListHeader.tsx
@@ -3,7 +3,7 @@ import { useContext, useState } from 'react';
 
 import { Chip, TextField } from '@mui/material';
 import { useNavigate } from 'react-router-dom';
-import CustomDialog from '../../components/CustomDialog/CustomDialog';
+import { CustomDialog } from '../../components/CustomDialog/CustomDialog';
 import AppContext from '../../contexts/AppContext';
 import { useSnackBar, useWindowDimensions } from '../../hooks';
 import { List, UpdateList } from '../../services/apiTypes';

--- a/src/pages/listDetails/sidelist/SideList.tsx
+++ b/src/pages/listDetails/sidelist/SideList.tsx
@@ -1,20 +1,19 @@
+import SubdirectoryArrowRightIcon from '@mui/icons-material/SubdirectoryArrowRight';
+import { IconButton } from '@mui/material';
 import { useContext, useState } from 'react';
 import { useParams } from 'react-router-dom';
-import { Item, MutateItemList } from '../../../services/apiTypes.ts';
-import { useRemoveItemsFromList } from '../../../services/hooks/items/useRemoveItemsFromList.tsx';
-import SubdirectoryArrowRightIcon from '@mui/icons-material/SubdirectoryArrowRight';
-import IconButton from '@mui/material/IconButton';
-
-import CustomDialog from '../../../components/CustomDialog/CustomDialog.tsx';
-import AppContext from '../../../contexts/AppContext.tsx';
-import { RemoveIcon, Wrapper } from './styles.ts';
-import { useAddItemsToList } from '../../../services/hooks/items/useAddItemsToList.tsx';
+import { CustomDialog } from '../../../components/CustomDialog/CustomDialog.tsx';
 import {
-    StyledContent,
-    StyledTitle,
-    StyledText,
     StyleIcons,
+    StyledContent,
+    StyledText,
+    StyledTitle,
 } from '../../../components/ItemCard/SearchInfo/styles.ts';
+import AppContext from '../../../contexts/AppContext.tsx';
+import { Item, MutateItemList } from '../../../services/apiTypes.ts';
+import { useAddItemsToList } from '../../../services/hooks/items/useAddItemsToList.tsx';
+import { useRemoveItemsFromList } from '../../../services/hooks/items/useRemoveItemsFromList.tsx';
+import { RemoveIcon, Wrapper } from './styles.ts';
 
 type Props = {
     item: Item;


### PR DESCRIPTION
## Pull Request Summary

### What is missing from the codebase?

Currently, custom dialog doesn't use `type´

### Changes made in this pull request:

- removed unused `type`
- use named export instead of default

## Checklist

-   [x] **Review**: Have you reviewed your own changes to ensure they align with best practices?
