### PR TITLE
Fix/display revnr productnumber in select + fix type from template

### DIFF
--- a/src/components/AddItemFormFields/TemplateTypes/TemplateTypes.tsx
+++ b/src/components/AddItemFormFields/TemplateTypes/TemplateTypes.tsx
@@ -27,7 +27,9 @@ export const Type: FC = () => {
         name: 'itemTemplate.type',
     });
 
-    const selectedType = options.find((option) => option.label === value);
+    const selectedType = options.find(
+        (option) => option.label.toLowerCase() === value.toLowerCase()
+    );
 
     return (
         <>

--- a/src/pages/addItem/hooks/itemValidator.ts
+++ b/src/pages/addItem/hooks/itemValidator.ts
@@ -8,6 +8,7 @@ const templateSchema = z.object({
     productNumber: z.string().min(1, 'Product number is required'),
     description: z.string(),
     createdById: z.string(),
+    revision: z.string().nullish(),
 });
 
 export const itemSchema = z.object({

--- a/src/pages/addItem/template/Template.tsx
+++ b/src/pages/addItem/template/Template.tsx
@@ -42,7 +42,11 @@ export default function Template() {
                         }}
                         id="free-solo-dialog-demo"
                         selectOnFocus
-                        getOptionLabel={(option) => option?.id}
+                        getOptionLabel={(option) =>
+                            `${
+                                option?.revision ? `${option.revision}-` : ''
+                            }${option?.productNumber}`
+                        }
                         clearOnBlur
                         handleHomeEndKeys
                         sx={{ width: '100%' }}
@@ -53,7 +57,9 @@ export default function Template() {
                         renderOption={(props, option) => {
                             return (
                                 <Box component="li" {...props} key={option?.id}>
-                                    {option?.id}
+                                    {`${
+                                        option?.revision ? `${option.revision}-` : ''
+                                    }${option?.productNumber}`}
                                 </Box>
                             );
                         }}


### PR DESCRIPTION
## Pull Request Summary

### What is missing from the codebase?

Currently, it shows id when selecting template, and type is not showed when using template

### Changes made in this pull request:

- fix showing type when using template
- shows revision number and product number when selecting template

## Checklist

-   [x] **Review**: Have you reviewed your own changes to ensure they align with best practices?
