### PR TITLE
refactor: update url stucture for item page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -47,7 +47,7 @@ function App() {
                 <Route path="/find-items" element={<Search />} />
                 <Route path="search/:searchParam?" element={<Search />} />
 
-                <Route path=":id" element={<ItemDetails />} />
+                <Route path="item/:id" element={<ItemDetails />} />
                 <Route path="add-item" element={<AddItem />}>
                     <Route index element={<RecentlyAdded />} />
                     <Route path="batch" element={<BatchForm />} />

--- a/src/components/ItemCard/ItemCard.tsx
+++ b/src/components/ItemCard/ItemCard.tsx
@@ -23,7 +23,7 @@ const ItemCard = ({ item, icon }: ItemCardProps) => {
 
     const handleClick = () => {
         if (location.pathname.includes('make-list')) return;
-        navigate(`/${item.id}`);
+        navigate(`/item/${item.id}`);
     };
 
     const cursorStyle =

--- a/src/components/ItemCard/SearchInfo/SearchInfo.tsx
+++ b/src/components/ItemCard/SearchInfo/SearchInfo.tsx
@@ -29,8 +29,8 @@ export const SearchInfo = ({ item, icon }: ItemCardProps) => {
     const { mutate: mutateAddItemToList, isSuccess: addItemSuccess } = useAddItemsToList();
     const { mutate: mutateRemoveItemFromList } = useRemoveItemsFromList();
 
-    const handleAdd = (e: React.MouseEvent, ids: MutateItemList) => {
-        e.stopPropagation();
+    const handleAdd = (event: React.MouseEvent, ids: MutateItemList) => {
+        event.stopPropagation();
         const alreadyAdded = list?.items.some((item) => item.id === item.id);
         if (alreadyAdded) {
             {
@@ -53,8 +53,8 @@ export const SearchInfo = ({ item, icon }: ItemCardProps) => {
         handleClose();
     };
 
-    const handleDelete = (e: React.MouseEvent, ids: MutateItemList) => {
-        e.stopPropagation();
+    const handleDelete = (event: React.MouseEvent, ids: MutateItemList) => {
+        event.stopPropagation();
         mutateRemoveItemFromList(ids, {
             onSuccess: (removeData) => {
                 setSnackbarText(`${item.wpId} was removed`);
@@ -68,8 +68,8 @@ export const SearchInfo = ({ item, icon }: ItemCardProps) => {
         handleClose();
     };
 
-    const handleClickOpen = (e: React.MouseEvent) => {
-        e.stopPropagation();
+    const handleClickOpen = (event: React.MouseEvent) => {
+        event.stopPropagation();
         setOpen(true);
     };
 
@@ -101,8 +101,8 @@ export const SearchInfo = ({ item, icon }: ItemCardProps) => {
                             <StyledAddIcon
                                 alreadyAdded={alreadyAdded}
                                 active={addItemSuccess}
-                                onClick={(e) =>
-                                    handleAdd(e, {
+                                onClick={(event) =>
+                                    handleAdd(event, {
                                         itemId: item.id,
                                         listId: listId!,
                                     })
@@ -120,7 +120,7 @@ export const SearchInfo = ({ item, icon }: ItemCardProps) => {
                     {location.pathname.includes('/make-list') && (
                         <StyledInfoIcon
                             onClick={() => {
-                                navigate(`/${item.id}`);
+                                navigate(`/item/${item.id}`);
                             }}
                         ></StyledInfoIcon>
                     )}
@@ -139,8 +139,8 @@ export const SearchInfo = ({ item, icon }: ItemCardProps) => {
                 open={open}
                 onClose={handleClose}
                 CancelButtonOnClick={handleClose}
-                SubmitButtonOnClick={(e) =>
-                    handleDelete(e, {
+                SubmitButtonOnClick={(event: React.MouseEvent) =>
+                    handleDelete(event, {
                         itemId: item.id,
                         listId: listId!,
                     })

--- a/src/components/ItemCard/SearchInfoCompact/SearchInfoCompact.tsx
+++ b/src/components/ItemCard/SearchInfoCompact/SearchInfoCompact.tsx
@@ -36,8 +36,8 @@ const SearchResultCardCompact = ({ item, icon }: ItemCardProps) => {
     const { mutate: mutateAddItemToList, isSuccess: addItemSuccess } = useAddItemsToList();
     const { mutate: mutateRemoveItemFromList } = useRemoveItemsFromList();
 
-    const handleAdd = (e: React.MouseEvent, ids: MutateItemList) => {
-        e.stopPropagation();
+    const handleAdd = (event: React.MouseEvent, ids: MutateItemList) => {
+        event.stopPropagation();
         const alreadyAdded = list?.items.some((item) => item.id === item.id);
         if (alreadyAdded) {
             {
@@ -59,8 +59,8 @@ const SearchResultCardCompact = ({ item, icon }: ItemCardProps) => {
         });
         handleClose();
     };
-    const handleDelete = (e: React.MouseEvent, ids: MutateItemList) => {
-        e.stopPropagation();
+    const handleDelete = (event: React.MouseEvent, ids: MutateItemList) => {
+        event.stopPropagation();
         mutateRemoveItemFromList(ids, {
             onSuccess: (removeData) => {
                 setSnackbarText(`${item.wpId} was removed`);
@@ -73,8 +73,8 @@ const SearchResultCardCompact = ({ item, icon }: ItemCardProps) => {
         });
         handleClose();
     };
-    const handleClickOpen = (e: React.MouseEvent) => {
-        e.stopPropagation();
+    const handleClickOpen = (event: React.MouseEvent) => {
+        event.stopPropagation();
         setOpen(true);
     };
     const handleClose = () => {
@@ -129,7 +129,7 @@ const SearchResultCardCompact = ({ item, icon }: ItemCardProps) => {
                         <Button
                             component={NavLink}
                             to={`/${item.id}`}
-                            onClick={() => navigate(`/${item.id}`)}
+                            onClick={() => navigate(`/item/${item.id}`)}
                         >
                             Show more
                         </Button>
@@ -160,8 +160,8 @@ const SearchResultCardCompact = ({ item, icon }: ItemCardProps) => {
                 open={open}
                 onClose={handleClose}
                 CancelButtonOnClick={handleClose}
-                SubmitButtonOnClick={(e) =>
-                    handleDelete(e, {
+                SubmitButtonOnClick={(event: React.MouseEvent) =>
+                    handleDelete(event, {
                         itemId: item.id,
                         listId: listId!,
                     })

--- a/src/components/ResultSearchCard/ResultSearchCard.tsx
+++ b/src/components/ResultSearchCard/ResultSearchCard.tsx
@@ -19,7 +19,7 @@ const SearchResultCard = ({ item, icon }: Props) => {
                     cursor: `${location.pathname.includes(`/makelist`) ? null : `pointer`}`,
                 }}
                 onClick={() => {
-                    location.pathname.includes('/makelist') ? null : navigate(`/${item.id}`);
+                    location.pathname.includes('/makelist') ? null : navigate(`/item/${item.id}`);
                 }}
             >
                 <StyledSearchCard title="">

--- a/src/pages/itemDetails/Index.tsx
+++ b/src/pages/itemDetails/Index.tsx
@@ -43,12 +43,15 @@ const ItemDetails = () => {
                 <BreadcrumbsMargin>
                     <Breadcrumbs>
                         <BreadcrumbLink
-                            onClick={() => navigate(`/${item.parentId}`)}
+                            onClick={() => navigate(`/item/${item.parentId}`)}
                             underline="none"
                         >
                             {parentItem?.itemTemplate?.type}: {item.parent?.wpId}
                         </BreadcrumbLink>
-                        <BreadcrumbLink onClick={() => navigate(`/${item.id}`)} underline="none">
+                        <BreadcrumbLink
+                            onClick={() => navigate(`/item/${item.id}`)}
+                            underline="none"
+                        >
                             {item.itemTemplate.type}: {item.wpId}
                         </BreadcrumbLink>
                     </Breadcrumbs>

--- a/src/pages/itemDetails/hierarchy/ChildItemSelector.tsx
+++ b/src/pages/itemDetails/hierarchy/ChildItemSelector.tsx
@@ -102,7 +102,9 @@ export const ChildItemSelector = ({
                     {item.children?.map((childItem) => {
                         return (
                             <ChildItemContainer key={childItem.wpId}>
-                                <StyledLinkElement onClick={() => navigate(`/${childItem.id}`)}>
+                                <StyledLinkElement
+                                    onClick={() => navigate(`/item/${childItem.id}`)}
+                                >
                                     {childItem.wpId}
                                 </StyledLinkElement>
 

--- a/src/pages/itemDetails/hierarchy/ParentItemSelector.tsx
+++ b/src/pages/itemDetails/hierarchy/ParentItemSelector.tsx
@@ -122,7 +122,7 @@ export const ParentItemSelector = ({
                     </LabelContainer>
 
                     <StyledContainer>
-                        <StyledLinkElement onClick={() => navigate(`/${item.parent?.id}`)}>
+                        <StyledLinkElement onClick={() => navigate(`/item/${item.parent?.id}`)}>
                             {item.parent?.wpId}
                         </StyledLinkElement>
                         {isOpen.parent && item.parent?.id && (


### PR DESCRIPTION
## Pull Request Summary

### What is missing from the codebase?

Currently, the URL structure only included the webpage name/id, lacking clarity on the page context.

### Changes made in this pull request:

- Introduced a keyword 'item' to enhance clarity and context in the URL structure.
- Updated all navigation paths to include '/item/' prefix.
- fix type issue for event

## Checklist

-   [x] **Review**: Have you reviewed your own changes to ensure they align with best practices?
