### PR TITLE
126 removehide searched list item when added to list

### DIFF
--- a/src/components/ItemCard/ItemCard.tsx
+++ b/src/components/ItemCard/ItemCard.tsx
@@ -6,6 +6,7 @@ import { StyledItemCardContainer, StyledSearchCard } from './styles';
 export type ItemCardProps = {
     item: {
         id: string;
+
         wpId: string;
         serialNumber: string;
         location?: Location;

--- a/src/components/ItemCard/SearchInfo/SearchInfo.tsx
+++ b/src/components/ItemCard/SearchInfo/SearchInfo.tsx
@@ -2,6 +2,7 @@ import { useNavigate, useParams } from 'react-router-dom';
 import { CustomDialog } from '../../CustomDialog/CustomDialog';
 import { StyledAddIcon, StyledInfoIcon, StyledRemoveIcon } from '../../ListCard/styles';
 import { ItemCardProps } from '../ItemCard';
+
 import { useCardActions } from '../hooks/useCardActions';
 import {
     StyledBox,

--- a/src/components/ItemCard/SearchInfo/SearchInfo.tsx
+++ b/src/components/ItemCard/SearchInfo/SearchInfo.tsx
@@ -75,8 +75,8 @@ export const SearchInfo = ({ item, icon }: ItemCardProps) => {
                         ></StyledInfoIcon>
                     )}
                     <StyledContent>
-                        <StyledTitle>Location</StyledTitle>
-                        <StyledText>{item.location?.name ?? 'Location'}</StyledText>
+                        <StyledTitle>Vendor</StyledTitle>
+                        <StyledText>{item.vendor?.name}</StyledText>
                     </StyledContent>
                     <StyledContent>
                         <StyledTitle>Category</StyledTitle>

--- a/src/components/ItemCard/SearchInfo/SearchInfo.tsx
+++ b/src/components/ItemCard/SearchInfo/SearchInfo.tsx
@@ -2,7 +2,6 @@ import { useNavigate, useParams } from 'react-router-dom';
 import { CustomDialog } from '../../CustomDialog/CustomDialog';
 import { StyledAddIcon, StyledInfoIcon, StyledRemoveIcon } from '../../ListCard/styles';
 import { ItemCardProps } from '../ItemCard';
-
 import { useCardActions } from '../hooks/useCardActions';
 import {
     StyledBox,

--- a/src/components/ItemCard/SearchInfo/SearchInfo.tsx
+++ b/src/components/ItemCard/SearchInfo/SearchInfo.tsx
@@ -9,7 +9,7 @@ import {
     StyledContainer,
     StyledContent,
     StyledDescriptionParagraph,
-    StyledSecondInfoBox,
+    StyledInfoBox,
     StyledText,
     StyledTitle,
 } from './styles';
@@ -40,11 +40,11 @@ export const SearchInfo = ({ item, icon }: ItemCardProps) => {
                         <StyledText>{item.itemTemplate?.productNumber}</StyledText>
                     </StyledContent>
                 </StyledBox>
-                <StyledSecondInfoBox>
+                <StyledInfoBox>
                     <StyledDescriptionParagraph>
                         {item.itemTemplate?.description}
                     </StyledDescriptionParagraph>
-                </StyledSecondInfoBox>
+                </StyledInfoBox>
                 <StyledBox>
                     <>
                         {icon === 'add' ? (

--- a/src/components/ItemCard/SearchInfo/SearchInfo.tsx
+++ b/src/components/ItemCard/SearchInfo/SearchInfo.tsx
@@ -1,13 +1,8 @@
-import { useContext, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
-import AppContext from '../../../contexts/AppContext';
-import { MutateItemList } from '../../../services/apiTypes';
-import { useAddItemsToList } from '../../../services/hooks/items/useAddItemsToList';
-import { useRemoveItemsFromList } from '../../../services/hooks/items/useRemoveItemsFromList';
-import { useGetListById } from '../../../services/hooks/list/useGetListById';
 import { CustomDialog } from '../../CustomDialog/CustomDialog';
 import { StyledAddIcon, StyledInfoIcon, StyledRemoveIcon } from '../../ListCard/styles';
 import { ItemCardProps } from '../ItemCard';
+import { useCardActions } from '../hooks/useCardActions';
 import {
     StyledBox,
     StyledContainer,
@@ -19,63 +14,17 @@ import {
 } from './styles';
 
 export const SearchInfo = ({ item, icon }: ItemCardProps) => {
-    const { setSnackbarText, setSnackbarSeverity } = useContext(AppContext);
-
-    const [open, setOpen] = useState(false);
-    const [alreadyAdded, setAlreadyAdded] = useState(false);
     const { listId } = useParams();
     const navigate = useNavigate();
-    const { data: list } = useGetListById(listId!);
-    const { mutate: mutateAddItemToList, isSuccess: addItemSuccess } = useAddItemsToList();
-    const { mutate: mutateRemoveItemFromList } = useRemoveItemsFromList();
-
-    const handleAdd = (e: React.MouseEvent, ids: MutateItemList) => {
-        e.stopPropagation();
-        const alreadyAdded = list?.items.some((item) => item.id === item.id);
-        if (alreadyAdded) {
-            {
-                setAlreadyAdded(true);
-            }
-            setSnackbarSeverity('error');
-            setSnackbarText('already in list');
-        }
-        mutateAddItemToList(ids, {
-            onSuccess: (data) => {
-                if (alreadyAdded) return;
-                setSnackbarText(`${item.wpId} was added`);
-
-                if (data.status >= 400) {
-                    setSnackbarSeverity('error');
-                    setSnackbarText(`${data.statusText}, please try again.`);
-                }
-            },
-        });
-        handleClose();
-    };
-
-    const handleDelete = (e: React.MouseEvent, ids: MutateItemList) => {
-        e.stopPropagation();
-        mutateRemoveItemFromList(ids, {
-            onSuccess: (removeData) => {
-                setSnackbarText(`${item.wpId} was removed`);
-
-                if (removeData.status >= 400) {
-                    setSnackbarSeverity('error');
-                    setSnackbarText(`${removeData.statusText}, please try again.`);
-                }
-            },
-        });
-        handleClose();
-    };
-
-    const handleClickOpen = (e: React.MouseEvent) => {
-        e.stopPropagation();
-        setOpen(true);
-    };
-
-    const handleClose = () => {
-        setOpen(false);
-    };
+    const {
+        handleAdd,
+        handleDelete,
+        handleClickOpen,
+        handleClose,
+        addItemSuccess,
+        alreadyAdded,
+        open,
+    } = useCardActions({ item: item });
 
     return (
         <>

--- a/src/components/ItemCard/SearchInfo/styles.ts
+++ b/src/components/ItemCard/SearchInfo/styles.ts
@@ -46,8 +46,9 @@ export const StyledTitle = styled.p`
 `;
 
 export const StyledText = styled.p`
-    margin: 0px;
+    margin: 0;
     display: flex;
+    width: max-content;
 `;
 
 export const StyledContainer = styled.div`

--- a/src/components/ItemCard/SearchInfo/styles.ts
+++ b/src/components/ItemCard/SearchInfo/styles.ts
@@ -10,7 +10,7 @@ export const StyledDescriptionParagraph = styled.p`
     -webkit-line-clamp: 5;
 `;
 
-export const StyledSecondInfoBox = styled.div`
+export const StyledInfoBox = styled.div`
     margin-top: 16px;
     margin-bottom: 16px;
     padding-left: 16px;

--- a/src/components/ItemCard/SearchInfo/styles.ts
+++ b/src/components/ItemCard/SearchInfo/styles.ts
@@ -11,7 +11,6 @@ export const StyledDescriptionParagraph = styled.p`
 `;
 
 export const StyledSecondInfoBox = styled.div`
-    /* margin: 16px; */
     margin-top: 16px;
     margin-bottom: 16px;
     padding-left: 16px;
@@ -28,7 +27,7 @@ export const StyledBox = styled.div`
     justify-content: space-between;
     margin: 16px;
     gap: 16px;
-    width: 400px; //TODO: this is not a good solution
+    width: 100%;
 `;
 
 export const StyledContent = styled.div`

--- a/src/components/ItemCard/SearchInfo/styles.ts
+++ b/src/components/ItemCard/SearchInfo/styles.ts
@@ -34,6 +34,9 @@ export const StyledContent = styled.div`
     display: flex;
     flex-direction: column;
     gap: 4px;
+    width: 100%;
+    padding-left: 5px;
+    padding-right: 5px;
 `;
 
 export const StyledTitle = styled.p`

--- a/src/components/ItemCard/SearchInfoCompact/SearchInfoCompact.tsx
+++ b/src/components/ItemCard/SearchInfoCompact/SearchInfoCompact.tsx
@@ -37,7 +37,7 @@ const SearchResultCardCompact = ({ item, icon }: ItemCardProps) => {
     } = useCardActions({ item: item });
 
     const { data: itemTemplateData } = useGetItemTemplateById(item.itemTemplate.id);
-    const { data: itemm } = useGetItemById(item.id);
+    const { data: itemById } = useGetItemById(item.id);
 
     return (
         <>
@@ -60,7 +60,9 @@ const SearchResultCardCompact = ({ item, icon }: ItemCardProps) => {
                             </StyledCompactContent>
                             <StyledCompactContent>
                                 <StyledCompactTitle>Vendor</StyledCompactTitle>
-                                <StyledCompactText>{itemm?.vendor?.name ?? ''}</StyledCompactText>
+                                <StyledCompactText>
+                                    {itemById?.vendor?.name ?? ''}
+                                </StyledCompactText>
                             </StyledCompactContent>
                             <StyledCompactContent>
                                 <StyledCompactTitle>Category</StyledCompactTitle>

--- a/src/components/ItemCard/SearchInfoCompact/SearchInfoCompact.tsx
+++ b/src/components/ItemCard/SearchInfoCompact/SearchInfoCompact.tsx
@@ -6,16 +6,13 @@ import {
     AccordionSummary,
     Button,
 } from '@mui/material';
-import React, { useContext, useState } from 'react';
 import { NavLink, useNavigate, useParams } from 'react-router-dom';
-import AppContext from '../../../contexts/AppContext';
-import { MutateItemList } from '../../../services/apiTypes';
-import { useAddItemsToList } from '../../../services/hooks/items/useAddItemsToList';
-import { useRemoveItemsFromList } from '../../../services/hooks/items/useRemoveItemsFromList';
-import { useGetListById } from '../../../services/hooks/list/useGetListById';
+import { useGetItemById } from '../../../services/hooks/items/useGetItemById';
+import { useGetItemTemplateById } from '../../../services/hooks/template/useGetItemTemplateById';
 import { CustomDialog } from '../../CustomDialog/CustomDialog';
 import { StyledAddIcon, StyledRemoveIcon } from '../../ListCard/styles';
 import { ItemCardProps } from '../ItemCard';
+import { useCardActions } from '../hooks/useCardActions';
 import {
     StyledCompactBox,
     StyledCompactContent,
@@ -27,60 +24,21 @@ import {
 } from './styles';
 
 const SearchResultCardCompact = ({ item, icon }: ItemCardProps) => {
-    const { setSnackbarText, setSnackbarSeverity } = useContext(AppContext);
     const navigate = useNavigate();
-    const [open, setOpen] = useState(false);
-    const [alreadyAdded, setAlreadyAdded] = useState(false);
     const { listId } = useParams();
-    const { data: list } = useGetListById(listId!);
-    const { mutate: mutateAddItemToList, isSuccess: addItemSuccess } = useAddItemsToList();
-    const { mutate: mutateRemoveItemFromList } = useRemoveItemsFromList();
+    const {
+        handleAdd,
+        handleDelete,
+        handleClickOpen,
+        handleClose,
+        addItemSuccess,
+        alreadyAdded,
+        open,
+    } = useCardActions({ item: item });
 
-    const handleAdd = (e: React.MouseEvent, ids: MutateItemList) => {
-        e.stopPropagation();
-        const alreadyAdded = list?.items.some((item) => item.id === item.id);
-        if (alreadyAdded) {
-            {
-                setAlreadyAdded(true);
-            }
-            setSnackbarSeverity('error');
-            setSnackbarText('already in list');
-        }
-        mutateAddItemToList(ids, {
-            onSuccess: (data) => {
-                if (alreadyAdded) return;
-                setSnackbarText(`${item.wpId} was added`);
-
-                if (data.status >= 400) {
-                    setSnackbarSeverity('error');
-                    setSnackbarText(`${data.statusText}, please try again.`);
-                }
-            },
-        });
-        handleClose();
-    };
-    const handleDelete = (e: React.MouseEvent, ids: MutateItemList) => {
-        e.stopPropagation();
-        mutateRemoveItemFromList(ids, {
-            onSuccess: (removeData) => {
-                setSnackbarText(`${item.wpId} was removed`);
-
-                if (removeData.status >= 400) {
-                    setSnackbarSeverity('error');
-                    setSnackbarText(`${removeData.statusText}, please try again.`);
-                }
-            },
-        });
-        handleClose();
-    };
-    const handleClickOpen = (e: React.MouseEvent) => {
-        e.stopPropagation();
-        setOpen(true);
-    };
-    const handleClose = () => {
-        setOpen(false);
-    };
-
+    const { data: itemTemplateData } = useGetItemTemplateById(item.itemTemplate.id);
+    const { data: itemm } = useGetItemById(item.id);
+    console.log(itemm);
     return (
         <>
             <StyledItemCardCompactContainer>
@@ -107,12 +65,12 @@ const SearchResultCardCompact = ({ item, icon }: ItemCardProps) => {
                             </StyledCompactContent>
                             <StyledCompactContent>
                                 <StyledCompactTitle>Location</StyledCompactTitle>
-                                <StyledCompactText>{item.location?.name ?? ''}</StyledCompactText>
+                                <StyledCompactText>{itemm?.location?.name ?? ''}</StyledCompactText>
                             </StyledCompactContent>
                             <StyledCompactContent>
                                 <StyledCompactTitle>Category</StyledCompactTitle>
                                 <StyledCompactText>
-                                    {item.itemTemplate.category?.name ?? 'Category'}
+                                    {itemTemplateData?.category?.name}
                                 </StyledCompactText>
                             </StyledCompactContent>
                         </StyledCompactBox>
@@ -121,7 +79,7 @@ const SearchResultCardCompact = ({ item, icon }: ItemCardProps) => {
                         <StyledCompactDescriptionWrap>
                             <StyledCompactTitle>Description</StyledCompactTitle>
                             <StyledCompactDescriptionParagraph>
-                                {item.itemTemplate.description}
+                                {item.itemTemplate?.description}
                             </StyledCompactDescriptionParagraph>
                         </StyledCompactDescriptionWrap>
                     </AccordionDetails>

--- a/src/components/ItemCard/SearchInfoCompact/SearchInfoCompact.tsx
+++ b/src/components/ItemCard/SearchInfoCompact/SearchInfoCompact.tsx
@@ -38,7 +38,7 @@ const SearchResultCardCompact = ({ item, icon }: ItemCardProps) => {
 
     const { data: itemTemplateData } = useGetItemTemplateById(item.itemTemplate.id);
     const { data: itemm } = useGetItemById(item.id);
-    console.log(itemm);
+
     return (
         <>
             <StyledItemCardCompactContainer>
@@ -49,23 +49,18 @@ const SearchResultCardCompact = ({ item, icon }: ItemCardProps) => {
                     }}
                 >
                     <AccordionSummary
-                        style={{
-                            display: 'flex',
-                            minWidth: '300px',
-                            gap: '16px',
-                        }}
                         expandIcon={<ExpandMoreIcon />}
                         aria-controls="panel1a-content"
                         id="panel1a-header"
                     >
                         <StyledCompactBox>
                             <StyledCompactContent>
-                                <StyledCompactTitle>ID:</StyledCompactTitle>
+                                <StyledCompactTitle>ID</StyledCompactTitle>
                                 <StyledCompactText>{item.wpId}</StyledCompactText>
                             </StyledCompactContent>
                             <StyledCompactContent>
-                                <StyledCompactTitle>Location</StyledCompactTitle>
-                                <StyledCompactText>{itemm?.location?.name ?? ''}</StyledCompactText>
+                                <StyledCompactTitle>Vendor</StyledCompactTitle>
+                                <StyledCompactText>{itemm?.vendor?.name ?? ''}</StyledCompactText>
                             </StyledCompactContent>
                             <StyledCompactContent>
                                 <StyledCompactTitle>Category</StyledCompactTitle>

--- a/src/components/ItemCard/SearchInfoCompact/SearchInfoCompact.tsx
+++ b/src/components/ItemCard/SearchInfoCompact/SearchInfoCompact.tsx
@@ -76,7 +76,7 @@ const SearchResultCardCompact = ({ item, icon }: ItemCardProps) => {
                     <AccordionActions>
                         <Button
                             component={NavLink}
-                            to={`/${item.id}`}
+                            to={`/item/${item.id}`}
                             onClick={() => navigate(`/item/${item.id}`)}
                         >
                             Show more

--- a/src/components/ItemCard/SearchInfoCompact/SearchInfoCompact.tsx
+++ b/src/components/ItemCard/SearchInfoCompact/SearchInfoCompact.tsx
@@ -7,8 +7,6 @@ import {
     Button,
 } from '@mui/material';
 import { NavLink, useNavigate, useParams } from 'react-router-dom';
-import { useGetItemById } from '../../../services/hooks/items/useGetItemById';
-import { useGetItemTemplateById } from '../../../services/hooks/template/useGetItemTemplateById';
 import { CustomDialog } from '../../CustomDialog/CustomDialog';
 import { StyledAddIcon, StyledRemoveIcon } from '../../ListCard/styles';
 import { ItemCardProps } from '../ItemCard';
@@ -36,9 +34,6 @@ const SearchResultCardCompact = ({ item, icon }: ItemCardProps) => {
         open,
     } = useCardActions({ item: item });
 
-    const { data: itemTemplateData } = useGetItemTemplateById(item.itemTemplate.id);
-    const { data: itemById } = useGetItemById(item.id);
-
     return (
         <>
             <StyledItemCardCompactContainer>
@@ -60,14 +55,12 @@ const SearchResultCardCompact = ({ item, icon }: ItemCardProps) => {
                             </StyledCompactContent>
                             <StyledCompactContent>
                                 <StyledCompactTitle>Vendor</StyledCompactTitle>
-                                <StyledCompactText>
-                                    {itemById?.vendor?.name ?? ''}
-                                </StyledCompactText>
+                                <StyledCompactText>{item?.vendor?.name ?? ''}</StyledCompactText>
                             </StyledCompactContent>
                             <StyledCompactContent>
                                 <StyledCompactTitle>Category</StyledCompactTitle>
                                 <StyledCompactText>
-                                    {itemTemplateData?.category?.name}
+                                    {item?.itemTemplate?.category?.name}
                                 </StyledCompactText>
                             </StyledCompactContent>
                         </StyledCompactBox>

--- a/src/components/ItemCard/SearchInfoCompact/styles.ts
+++ b/src/components/ItemCard/SearchInfoCompact/styles.ts
@@ -22,13 +22,15 @@ export const StyledCompactInfoP = styled.div`
 export const StyledCompactContent = styled.div`
     display: flex;
     flex-direction: column;
-    gap: 2px;
+    width: 100%;
+    gap: 10px;
 `;
 
 export const StyledCompactDescriptionWrap = styled.div`
     display: flex;
     flex-direction: column;
     gap: 2px;
+    width: 100%;
 `;
 
 export const StyledCompactDescriptionParagraph = styled.p`
@@ -61,4 +63,5 @@ export const StyledCompactBox = styled.div`
     display: flex;
     justify-content: space-between;
     width: 100%;
+    margin: 10px 0;
 `;

--- a/src/components/ItemCard/hooks/useCardActions.tsx
+++ b/src/components/ItemCard/hooks/useCardActions.tsx
@@ -1,0 +1,80 @@
+import { useContext, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import AppContext from '../../../contexts/AppContext';
+import { MutateItemList } from '../../../services/apiTypes';
+import { useAddItemsToList } from '../../../services/hooks/items/useAddItemsToList';
+import { useRemoveItemsFromList } from '../../../services/hooks/items/useRemoveItemsFromList';
+import { useGetListById } from '../../../services/hooks/list/useGetListById';
+import { ItemCardProps } from '../ItemCard';
+
+export const useCardActions = ({ item }: ItemCardProps) => {
+    const { setSnackbarText, setSnackbarSeverity } = useContext(AppContext);
+    const navigate = useNavigate();
+    const [open, setOpen] = useState(false);
+    const [alreadyAdded, setAlreadyAdded] = useState(false);
+    const { listId } = useParams();
+    const { data: list } = useGetListById(listId!);
+    const { mutate: mutateAddItemToList, isSuccess: addItemSuccess } = useAddItemsToList();
+    const { mutate: mutateRemoveItemFromList } = useRemoveItemsFromList();
+
+    const handleAdd = (e: React.MouseEvent, ids: MutateItemList) => {
+        e.stopPropagation();
+        const alreadyAdded = list?.items.some((listItem) => listItem.id === item.id);
+
+        if (alreadyAdded) {
+            {
+                setAlreadyAdded(true);
+            }
+            setSnackbarSeverity('error');
+            setSnackbarText('already in list');
+        } else {
+            mutateAddItemToList(ids, {
+                onSuccess: (data) => {
+                    setSnackbarText(`${item.wpId} was added`);
+
+                    if (data.status >= 400) {
+                        setSnackbarSeverity('error');
+                        setSnackbarText(`${data.statusText}, please try again.`);
+                    }
+                },
+            });
+        }
+        handleClose();
+    };
+
+    const handleDelete = (e: React.MouseEvent, ids: MutateItemList) => {
+        e.stopPropagation();
+        mutateRemoveItemFromList(ids, {
+            onSuccess: (removeData) => {
+                setSnackbarText(`${item.wpId} was removed`);
+
+                if (removeData.status >= 400) {
+                    setSnackbarSeverity('error');
+                    setSnackbarText(`${removeData.statusText}, please try again.`);
+                }
+            },
+        });
+        handleClose();
+    };
+
+    const handleClickOpen = (e: React.MouseEvent) => {
+        e.stopPropagation();
+        setOpen(true);
+    };
+
+    const handleClose = () => {
+        setOpen(false);
+    };
+
+    return {
+        handleAdd,
+        handleDelete,
+        handleClickOpen,
+        handleClose,
+        alreadyAdded,
+        open,
+        setOpen,
+        navigate,
+        addItemSuccess,
+    };
+};

--- a/src/components/ItemCard/styles.ts
+++ b/src/components/ItemCard/styles.ts
@@ -2,8 +2,6 @@ import { styled } from 'styled-components';
 import { COLORS } from '../../style/GlobalStyles';
 
 export const StyledItemCardContainer = styled.div`
-    /* margin: 16px;
-    padding: 4px; */
     width: 550px;
     margin-inline: auto;
 `;

--- a/src/components/Tabs/styles.ts
+++ b/src/components/Tabs/styles.ts
@@ -5,7 +5,7 @@ export const StyledTabContainer = styled.section`
     display: flex;
     flex-direction: row;
     width: 100%;
-    border-bottom: 2px solid black;
+    border-bottom: 2px ${COLORS.black};
     height: 60px;
 `;
 export const StyledTabButton = styled.button<{ active: boolean }>`
@@ -23,7 +23,6 @@ export const StyledTabButton = styled.button<{ active: boolean }>`
 `;
 
 export const StyledNumberofItems = styled.span<{ active: boolean }>`
-    color: white;
     position: absolute;
     right: 0;
     padding: 1rem;
@@ -34,7 +33,7 @@ export const StyledTitle = styled.span<{ active: boolean }>`
     display: flex;
     text-transform: uppercase;
 
-    color: ${(props) => (props.active ? `${COLORS.black}` : ` ${COLORS.white}`)};
+    color: ${(props) => (props.active ? `${COLORS.white}` : ` ${COLORS.black}`)};
     transition: 0.6s;
 `;
 export const StyledIndicator = styled.span<{ active: boolean }>`

--- a/src/pages/addItem/hooks/itemValidator.ts
+++ b/src/pages/addItem/hooks/itemValidator.ts
@@ -3,6 +3,10 @@ import { z } from 'zod';
 const templateSchema = z.object({
     id: z.string(),
     inputValue: z.string().nullish(),
+    category: z.object({
+        id: z.string(),
+        name: z.string(),
+    }),
     type: z.string().min(1, 'type is required'),
     categoryId: z.string().min(1, 'category is required'),
     productNumber: z.string().min(1, 'Product number is required'),

--- a/src/pages/addItem/hooks/itemValidator.ts
+++ b/src/pages/addItem/hooks/itemValidator.ts
@@ -3,10 +3,12 @@ import { z } from 'zod';
 const templateSchema = z.object({
     id: z.string(),
     inputValue: z.string().nullish(),
-    category: z.object({
-        id: z.string(),
-        name: z.string(),
-    }),
+    category: z
+        .object({
+            id: z.string(),
+            name: z.string(),
+        })
+        .nullish(),
     type: z.string().min(1, 'type is required'),
     categoryId: z.string().min(1, 'category is required'),
     productNumber: z.string().min(1, 'Product number is required'),

--- a/src/pages/addItem/hooks/useAddItemForm.ts
+++ b/src/pages/addItem/hooks/useAddItemForm.ts
@@ -1,8 +1,8 @@
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useContext, useEffect } from 'react';
-import AppContext from '../../../contexts/AppContext';
 import { useForm } from 'react-hook-form';
 import { useLocation } from 'react-router-dom';
+import AppContext from '../../../contexts/AppContext';
 import { ItemTemplate } from '../../../services/apiTypes';
 import { useAddItems } from '../../../services/hooks/items/useAddItem';
 import { useAddItemTemplate } from '../../../services/hooks/template/useAddItemTemplate';

--- a/src/pages/listDetails/ListHeader.tsx
+++ b/src/pages/listDetails/ListHeader.tsx
@@ -90,11 +90,11 @@ export const ListHeader = ({ list }: Props) => {
         <>
             {width > 800 ? (
                 <Header>
+                    <ListTitle>{list.title}</ListTitle>
                     <Wrapper>
                         <StyledDate>
                             {format(new Date(list.createdDate), 'dd-MM-yyyy').toString()}
                         </StyledDate>
-                        <ListTitle>{list.title}</ListTitle>
                     </Wrapper>
                     <FlexContainer>
                         <IconContainer>
@@ -114,11 +114,11 @@ export const ListHeader = ({ list }: Props) => {
             ) : (
                 <>
                     <WrapperCompact>
+                        <ListTitle>{list.title}</ListTitle>
                         <Wrapper>
                             <StyledDate>
                                 {format(new Date(list.createdDate), 'dd-MM-yyyy').toString()}
                             </StyledDate>
-                            <ListTitle>{list.title}</ListTitle>
                         </Wrapper>
                         <IconContainerCompact>
                             <IconContainer onClick={(e) => handleOpenEdit(e)}>

--- a/src/pages/listDetails/phone/list/PhoneList.tsx
+++ b/src/pages/listDetails/phone/list/PhoneList.tsx
@@ -54,7 +54,6 @@ export const PhoneList = ({ list }: Props) => {
                                         item={item}
                                         icon={'remove'}
                                     />
-                                    // <SideList item={item} key={item.id} />
                                 ))}
                             </ListContainerCompact>
                         ) : null}

--- a/src/pages/listDetails/sidelist/SideList.tsx
+++ b/src/pages/listDetails/sidelist/SideList.tsx
@@ -68,7 +68,7 @@ export const SideList = ({ item }: Props) => {
                     </StyledContent>
                     <StyledContent>
                         <StyledTitle>Category</StyledTitle>
-                        <StyledText>{itemTemplateData?.category.name} </StyledText>
+                        <StyledText>{itemTemplateData?.category?.name ?? ''} </StyledText>
                     </StyledContent>
                     <StyledContent>
                         <StyledTitle>Vendor</StyledTitle>

--- a/src/pages/listDetails/sidelist/SideList.tsx
+++ b/src/pages/listDetails/sidelist/SideList.tsx
@@ -12,9 +12,7 @@ import {
 import AppContext from '../../../contexts/AppContext';
 import { Item, MutateItemList } from '../../../services/apiTypes';
 import { useAddItemsToList } from '../../../services/hooks/items/useAddItemsToList';
-import { useGetItemById } from '../../../services/hooks/items/useGetItemById';
 import { useRemoveItemsFromList } from '../../../services/hooks/items/useRemoveItemsFromList';
-import { useGetItemTemplateById } from '../../../services/hooks/template/useGetItemTemplateById';
 import { RemoveIcon, Wrapper } from './styles';
 
 type Props = {
@@ -56,8 +54,7 @@ export const SideList = ({ item }: Props) => {
     const handleClickOpen = () => {
         setOpen(true);
     };
-    const { data: itemTemplateData } = useGetItemTemplateById(item?.itemTemplate?.id);
-    const { data: itemm } = useGetItemById(item.id);
+
     return (
         <>
             <>
@@ -68,11 +65,11 @@ export const SideList = ({ item }: Props) => {
                     </StyledContent>
                     <StyledContent>
                         <StyledTitle>Category</StyledTitle>
-                        <StyledText>{itemTemplateData?.category?.name ?? ''} </StyledText>
+                        <StyledText>{item.itemTemplate.category.name ?? ''} </StyledText>
                     </StyledContent>
                     <StyledContent>
                         <StyledTitle>Vendor</StyledTitle>
-                        <StyledText>{itemm?.vendor.name ?? ''}</StyledText>
+                        <StyledText>{item?.vendor?.name ?? ''}</StyledText>
                     </StyledContent>
                     <StyleIcons>
                         <RemoveIcon onClick={handleClickOpen} />

--- a/src/pages/listDetails/sidelist/SideList.tsx
+++ b/src/pages/listDetails/sidelist/SideList.tsx
@@ -12,7 +12,9 @@ import {
 import AppContext from '../../../contexts/AppContext';
 import { Item, MutateItemList } from '../../../services/apiTypes';
 import { useAddItemsToList } from '../../../services/hooks/items/useAddItemsToList';
+import { useGetItemById } from '../../../services/hooks/items/useGetItemById';
 import { useRemoveItemsFromList } from '../../../services/hooks/items/useRemoveItemsFromList';
+import { useGetItemTemplateById } from '../../../services/hooks/template/useGetItemTemplateById';
 import { RemoveIcon, Wrapper } from './styles';
 
 type Props = {
@@ -54,7 +56,8 @@ export const SideList = ({ item }: Props) => {
     const handleClickOpen = () => {
         setOpen(true);
     };
-
+    const { data: itemTemplateData } = useGetItemTemplateById(item?.itemTemplate?.id);
+    const { data: itemm } = useGetItemById(item.id);
     return (
         <>
             <>
@@ -64,12 +67,12 @@ export const SideList = ({ item }: Props) => {
                         <StyledText>{item.serialNumber}</StyledText>
                     </StyledContent>
                     <StyledContent>
-                        <StyledTitle>Location</StyledTitle>
-                        <StyledText>{item.location?.name || 'Stavanger'}</StyledText>
+                        <StyledTitle>Category</StyledTitle>
+                        <StyledText>{itemTemplateData?.category.name} </StyledText>
                     </StyledContent>
                     <StyledContent>
                         <StyledTitle>Vendor</StyledTitle>
-                        <StyledText>{item.vendor?.name || 'Vendor'}</StyledText>
+                        <StyledText>{itemm?.vendor.name ?? ''}</StyledText>
                     </StyledContent>
                     <StyleIcons>
                         <RemoveIcon onClick={handleClickOpen} />

--- a/src/pages/listDetails/sidelist/styles.ts
+++ b/src/pages/listDetails/sidelist/styles.ts
@@ -25,6 +25,9 @@ export const DeleteIcon = styled(DeleteForeverIcon)`
 export const Wrapper = styled.div`
     display: flex;
     align-items: center;
+    /* display: grid;
+    grid-template-columns: 1fr 1fr 1fr auto;
+    column-gap: 10px; */
     box-shadow:
         rgba(60, 64, 67, 0.3) 0px 1px 2px 0px,
         rgba(60, 64, 67, 0.15) 0px 2px 6px 2px;

--- a/src/pages/listDetails/styles.ts
+++ b/src/pages/listDetails/styles.ts
@@ -87,6 +87,7 @@ export const IconContainer = styled.div``;
 
 export const ListTitle = styled.h3`
     font-weight: 600;
+    display: inline-flex;
 
     width: 100%;
     font-size: 1.2rem;


### PR DESCRIPTION
## Pull Request Summary

### What is missing from the codebase?

Currently, there was a bug where the snackbar and the add more to list component said "already added" although it had not been added, location is shown as null on the item list cards, and title on the tabs on the phone version of make list was not showing

### Changes made in this pull request:

-fixed snackbar /additem function so it displays correct message when adding items.
- changed location on itemcards on list and search results to vendor, since location was never showing
- fixed category so its shown on itemcards
- fixed title names so they are shown agian on tabs on phone version of make list component.
- overall styling fixes

## Checklist

-   [x] **Review**: Have you reviewed your own changes to ensure they align with best practices?
