### PR TITLE
fix: Implemented flex container with flex-wrap

### DIFF
--- a/src/components/AddItemFormFields/SerialNumber/SerialNumber.tsx
+++ b/src/components/AddItemFormFields/SerialNumber/SerialNumber.tsx
@@ -6,7 +6,13 @@ import { useDebounce } from 'usehooks-ts';
 import { ItemSchema } from '../../../pages/addItem/hooks/itemValidator.ts';
 import { useIsSerialNumberUnique } from '../../../services/hooks/items/useIsSerialNumberUnique.tsx';
 import { ToolTip } from '../../ToolTip/ToolTip.tsx';
-import { StyledDiv, StyledErrorP, StyledIconContainer, StyledInputWrap } from '../styles.ts';
+import {
+    EllipsisText,
+    StyledDiv,
+    StyledErrorP,
+    StyledIconContainer,
+    StyledInputWrap,
+} from '../styles.ts';
 
 import HelpOutlineIcon from '@mui/icons-material/HelpOutline';
 import { StyledParagraph } from '../WpId/styles.ts';
@@ -35,7 +41,7 @@ export const SerialNumber = ({
     }, [setValue, inputValue, isUnique]);
 
     if (isPlainText) {
-        return <p>{serialNumber}</p>;
+        return <EllipsisText>{serialNumber}</EllipsisText>;
     }
 
     return (

--- a/src/components/AddItemFormFields/WpId/WpId.tsx
+++ b/src/components/AddItemFormFields/WpId/WpId.tsx
@@ -7,7 +7,7 @@ import { useDebounce } from 'usehooks-ts';
 import { ItemSchema } from '../../../pages/addItem/hooks/itemValidator';
 import { useIsWpIdUnique } from '../../../services/hooks/items/useIsWpIdUnique';
 import { ToolTip } from '../../ToolTip/ToolTip';
-import { StyledDiv, StyledErrorP, StyledInputWrap } from '../styles';
+import { EllipsisText, StyledDiv, StyledErrorP, StyledInputWrap } from '../styles';
 import { StyledParagraph } from './styles';
 
 type WpIdProps = {
@@ -23,7 +23,6 @@ export const WpId = ({ fieldName, wpId, onChange, isPlainText }: WpIdProps) => {
     const [inputValue, setInputValue] = useState(wpId);
     const debouncedWpId = useDebounce(wpId, 500);
     const { data: isUnique, isLoading } = useIsWpIdUnique(debouncedWpId);
-
     useEffect(() => {
         setValue(fieldName as keyof ItemSchema, inputValue);
         setValue('uniqueWpId', isUnique!);
@@ -31,7 +30,7 @@ export const WpId = ({ fieldName, wpId, onChange, isPlainText }: WpIdProps) => {
     }, [setValue, inputValue, isUnique]);
 
     if (isPlainText) {
-        return <p>{wpId}</p>;
+        return <EllipsisText>{wpId}</EllipsisText>;
     }
     return (
         <>

--- a/src/components/AddItemFormFields/styles.ts
+++ b/src/components/AddItemFormFields/styles.ts
@@ -1,4 +1,5 @@
 import styled from 'styled-components';
+import { COLORS } from '../../style/GlobalStyles';
 
 export const StyledInputWrap = styled.div`
     display: flex;
@@ -27,4 +28,23 @@ export const StyledIconContainer = styled.div`
 export const StyledDiv = styled.div`
     max-width: 500px;
     padding-right: 5px;
+`;
+
+export const EllipsisText = styled.span`
+    flex: 1;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    min-width: 80px;
+`;
+
+export const ScrollWrapContainer = styled.div`
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+    max-width: 480px;
+    max-height: 50px;
+    overflow-y: auto;
+    border: 1px dotted ${COLORS.darkGray};
+    padding: 10px;
 `;

--- a/src/pages/addItem/addItemForm/FormContent.tsx
+++ b/src/pages/addItem/addItemForm/FormContent.tsx
@@ -16,11 +16,11 @@ import { CustomDialog } from '../../../components/CustomDialog/CustomDialog';
 import AppContext from '../../../contexts/AppContext';
 import { Edit, LabelContainer } from '../../itemDetails/itemInfo/styles';
 import { ItemSchema } from '../hooks/itemValidator';
+import { ScrollWrapContainer } from '../../../components/AddItemFormFields/styles';
 
 export const FormContent = () => {
     const { currentUser } = useContext(AppContext);
     const { register, getValues } = useFormContext<ItemSchema>();
-
     const [wpIds, setWpIds] = useState<string[]>([]);
     const [serialNumbers, setSerialNumbers] = useState<string[]>([]);
     const [isOpen, setIsOpen] = useState({
@@ -33,7 +33,6 @@ export const FormContent = () => {
         const uniqueWpIds = Array.from({ length: numberOfItems }, () => uuid().slice(0, 8));
         const uniqueSerialNumbers = Array.from({ length: numberOfItems }, () => uuid().slice(0, 8));
         setWpIds(uniqueWpIds);
-
         setSerialNumbers(uniqueSerialNumbers);
     }, [numberOfItems]);
 
@@ -66,7 +65,7 @@ export const FormContent = () => {
                     </label>
                     <Edit onClick={() => setIsOpen((prev) => ({ ...prev, wpId: true }))} />
                 </LabelContainer>
-                <div style={{ display: 'flex', gap: '10px' }}>
+                <ScrollWrapContainer>
                     {wpIds.map((wpId, index) => {
                         const fieldName = `wpId[${index}]`;
                         return (
@@ -81,7 +80,7 @@ export const FormContent = () => {
                             />
                         );
                     })}
-                </div>
+                </ScrollWrapContainer>
             </div>
 
             <CustomDialog
@@ -114,7 +113,7 @@ export const FormContent = () => {
                     <Edit onClick={() => setIsOpen((prev) => ({ ...prev, serialNumber: true }))} />
                 </LabelContainer>
 
-                <div style={{ display: 'flex', gap: '10px' }}>
+                <ScrollWrapContainer>
                     {serialNumbers.map((serialNumber, index) => {
                         const fieldName = `serialNumber[${index}]`;
                         return (
@@ -129,7 +128,7 @@ export const FormContent = () => {
                             />
                         );
                     })}
-                </div>
+                </ScrollWrapContainer>
             </div>
 
             <ProductNumber />


### PR DESCRIPTION
## Pull Request Summary

### What is missing from the codebase?

Currently, serialnumbers/wpids will not wrap to new line

### Changes made in this pull request:

- Ensured proper handling of overflow for serial numbers/wpids.

## Checklist

-   [x] **Review**: Have you reviewed your own changes to ensure they align with best practices?
