### PR TITLE
feat: added windows refresh reset form

### DIFF
--- a/src/components/AddItemFormFields/Category/Category.tsx
+++ b/src/components/AddItemFormFields/Category/Category.tsx
@@ -16,6 +16,7 @@ export const Category = () => {
         field: { onChange, value },
     } = useController({
         name: 'itemTemplate.categoryId',
+        defaultValue: '',
         control,
     });
     const selectedTemplate = watch('itemTemplate.id');
@@ -47,10 +48,12 @@ export const Category = () => {
                         <HelpOutlineIcon fontSize="small" />
                     </ToolTip>
                 </StyledIconContainer>
-                <ErrorMessage
-                    name="itemTemplate.categoryId"
-                    render={({ message }) => <StyledErrorP>{message}</StyledErrorP>}
-                />
+                {!watch('itemTemplate.categoryId') && (
+                    <ErrorMessage
+                        name="itemTemplate.categoryId"
+                        render={({ message }) => <StyledErrorP>{message}</StyledErrorP>}
+                    />
+                )}
             </StyledInputWrap>
             <Autocomplete
                 options={categoryOptions}
@@ -58,7 +61,7 @@ export const Category = () => {
                 isOptionEqualToValue={(option, value) => option.value === value.value}
                 size="small"
                 sx={{ width: '100%' }}
-                value={initialValue}
+                value={initialValue ?? null}
                 renderInput={(params) => (
                     <TextField {...params} label="Categories" variant="outlined" />
                 )}

--- a/src/components/AddItemFormFields/SerialNumber/SerialNumber.tsx
+++ b/src/components/AddItemFormFields/SerialNumber/SerialNumber.tsx
@@ -49,7 +49,7 @@ export const SerialNumber = ({
                         </ToolTip>
                     </StyledIconContainer>
                     <ErrorMessage
-                        name="serialNumber"
+                        name={`serialNumber[${0}]`}
                         render={({ message }) => <StyledErrorP>{message}</StyledErrorP>}
                     />
                 </StyledInputWrap>

--- a/src/components/AddItemFormFields/TemplateTypes/TemplateTypes.tsx
+++ b/src/components/AddItemFormFields/TemplateTypes/TemplateTypes.tsx
@@ -29,7 +29,7 @@ export const Type: FC = () => {
     });
 
     const selectedType = options.find(
-        (option) => option.label.toLowerCase() === value.toLowerCase()
+        (option) => option?.label.toLowerCase() === value.toLowerCase()
     );
 
     return (

--- a/src/components/AddItemFormFields/TemplateTypes/TemplateTypes.tsx
+++ b/src/components/AddItemFormFields/TemplateTypes/TemplateTypes.tsx
@@ -25,6 +25,7 @@ export const Type: FC = () => {
         control,
 
         name: 'itemTemplate.type',
+        defaultValue: '',
     });
 
     const selectedType = options.find(
@@ -41,10 +42,12 @@ export const Type: FC = () => {
                             <HelpOutlineIcon fontSize="small" />
                         </ToolTip>
                     </StyledIconContainer>
-                    <ErrorMessage
-                        name="itemTemplate.type"
-                        render={({ message }) => <StyledErrorP>{message}</StyledErrorP>}
-                    />
+                    {!watch('itemTemplate.type') && (
+                        <ErrorMessage
+                            name="itemTemplate.type"
+                            render={({ message }) => <StyledErrorP>{message}</StyledErrorP>}
+                        />
+                    )}
                 </StyledInputWrap>
                 <Autocomplete
                     options={options}
@@ -53,7 +56,7 @@ export const Type: FC = () => {
                     id="controlled-demo"
                     sx={{ width: '100%' }}
                     size="small"
-                    value={selectedType}
+                    value={selectedType ?? null}
                     isOptionEqualToValue={(option, value) => option.value === value.value}
                     disabled={!!selectedTemplate}
                     onChange={(_event, newValue) => {

--- a/src/components/AddItemFormFields/WpId/WpId.tsx
+++ b/src/components/AddItemFormFields/WpId/WpId.tsx
@@ -33,6 +33,7 @@ export const WpId = ({ fieldName, wpId, onChange, isPlainText }: WpIdProps) => {
     if (isPlainText) {
         return <p>{wpId}</p>;
     }
+
     return (
         <>
             <StyledDiv>
@@ -44,7 +45,7 @@ export const WpId = ({ fieldName, wpId, onChange, isPlainText }: WpIdProps) => {
                     </ToolTip>
 
                     <ErrorMessage
-                        name="wpId"
+                        name={`wpId[${0}]`}
                         render={({ message }) => <StyledErrorP>{message}</StyledErrorP>}
                     />
                 </StyledInputWrap>
@@ -57,7 +58,10 @@ export const WpId = ({ fieldName, wpId, onChange, isPlainText }: WpIdProps) => {
                     placeholder="E.g 5321-1"
                     variant="filled"
                     size="small"
-                    {...register(fieldName as keyof ItemSchema)}
+                    {...(register(fieldName as keyof ItemSchema),
+                    {
+                        required: true,
+                    })}
                     value={inputValue}
                     onChange={(e) => setInputValue(e.target.value)}
                     inputProps={{ name: 'isUnique', 'data-isunique': isUnique }}

--- a/src/components/AddItemFormFields/styles.ts
+++ b/src/components/AddItemFormFields/styles.ts
@@ -31,7 +31,6 @@ export const StyledDiv = styled.div`
 `;
 
 export const EllipsisText = styled.span`
-    flex: 1;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -43,6 +42,7 @@ export const ScrollWrapContainer = styled.div`
     flex-wrap: wrap;
     gap: 10px;
     max-width: 480px;
+    min-height: 20px;
     max-height: 50px;
     overflow-y: auto;
     border: 1px dotted ${COLORS.darkGray};

--- a/src/pages/addItem/Index.tsx
+++ b/src/pages/addItem/Index.tsx
@@ -3,6 +3,7 @@ import React, { useEffect } from 'react';
 import { FormProvider } from 'react-hook-form';
 import { Outlet, useNavigate } from 'react-router-dom';
 import ProgressBar from '../../components/ProgressBar/ProgressBar';
+
 import { StyledForm } from './addItemForm/styles';
 import { ItemSchema } from './hooks/itemValidator';
 import { useAddItemForm } from './hooks/useAddItemForm';
@@ -34,7 +35,7 @@ const steps: { fields: stepsSchema[]; slug: string }[] = [
 ];
 
 const AddItem = () => {
-    const { methods, onSubmit, trigger } = useAddItemForm();
+    const { methods, onSubmit, trigger, reset } = useAddItemForm();
     const navigate = useNavigate();
     const [activeStep, setActiveStep] = React.useState(0);
 
@@ -64,6 +65,26 @@ const AddItem = () => {
         setActiveStep(currentStep !== -1 ? currentStep : 0);
     }, [location.pathname]);
 
+    useEffect(() => {
+        const entries = performance.getEntriesByType('navigation');
+        if (entries && entries.length > 0 && 'type' in entries[0]) {
+            const navigationEntry: PerformanceNavigationTiming =
+                entries[0] as PerformanceNavigationTiming;
+            if (navigationEntry.type === 'reload') {
+                reset();
+                setActiveStep(0);
+                navigate(`/add-item/`);
+            }
+        }
+    }, []);
+
+    useEffect(() => {
+        window.onbeforeunload = () => true;
+
+        return () => {
+            window.onbeforeunload = null;
+        };
+    }, []);
     return (
         <FormProvider {...methods}>
             {steps.some((step) => location.pathname.includes(`/add-item/${step.slug}`)) && (

--- a/src/pages/addItem/Index.tsx
+++ b/src/pages/addItem/Index.tsx
@@ -3,7 +3,6 @@ import React, { useEffect } from 'react';
 import { FormProvider } from 'react-hook-form';
 import { Outlet, useNavigate } from 'react-router-dom';
 import ProgressBar from '../../components/ProgressBar/ProgressBar';
-
 import { StyledForm } from './addItemForm/styles';
 import { ItemSchema } from './hooks/itemValidator';
 import { useAddItemForm } from './hooks/useAddItemForm';

--- a/src/pages/addItem/addItemForm/FormContent.tsx
+++ b/src/pages/addItem/addItemForm/FormContent.tsx
@@ -1,3 +1,4 @@
+import { ErrorMessage } from '@hookform/error-message';
 import { TextField } from '@mui/material';
 import { SetStateAction, useContext, useEffect, useState } from 'react';
 import { useFormContext } from 'react-hook-form';
@@ -12,10 +13,12 @@ import { SerialNumber } from '../../../components/AddItemFormFields/SerialNumber
 import { Type } from '../../../components/AddItemFormFields/TemplateTypes/TemplateTypes';
 import { Vendor } from '../../../components/AddItemFormFields/Vendor/Vendor';
 import { WpId } from '../../../components/AddItemFormFields/WpId/WpId';
+import { StyledErrorP } from '../../../components/AddItemFormFields/styles';
 import { CustomDialog } from '../../../components/CustomDialog/CustomDialog';
 import AppContext from '../../../contexts/AppContext';
-import { Edit, LabelContainer } from '../../itemDetails/itemInfo/styles';
+import { Edit } from '../../itemDetails/itemInfo/styles';
 import { ItemSchema } from '../hooks/itemValidator';
+import { StyledFieldBox, StyledIconContainer, StyledLabelContainer } from './styles';
 
 export const FormContent = () => {
     const { currentUser } = useContext(AppContext);
@@ -60,30 +63,38 @@ export const FormContent = () => {
             <Type />
             <Category />
             <div>
-                <LabelContainer>
-                    <label>
-                        <strong>WP ids</strong>
-                    </label>
-                    <Edit onClick={() => setIsOpen((prev) => ({ ...prev, wpId: true }))} />
-                </LabelContainer>
-                <div style={{ display: 'flex', gap: '10px' }}>
+                <StyledLabelContainer>
+                    <StyledIconContainer>
+                        <label>
+                            <strong>WP ids</strong>
+                        </label>
+                        <Edit onClick={() => setIsOpen((prev) => ({ ...prev, wpId: true }))} />
+                    </StyledIconContainer>
+
+                    <ErrorMessage
+                        name={`wpId[${0}]`}
+                        as="span"
+                        render={({ message }) => <StyledErrorP>{message}</StyledErrorP>}
+                    />
+                </StyledLabelContainer>
+                <StyledFieldBox>
                     {wpIds.map((wpId, index) => {
                         const fieldName = `wpId[${index}]`;
                         return (
-                            <WpId
-                                key={index}
-                                wpId={wpId}
-                                fieldName={fieldName}
-                                isPlainText
-                                onChange={(value: string) =>
-                                    handleChange(wpIds, index, value, setWpIds)
-                                }
-                            />
+                            <div key={index}>
+                                <WpId
+                                    wpId={wpId}
+                                    fieldName={fieldName}
+                                    isPlainText
+                                    onChange={(value: string) =>
+                                        handleChange(wpIds, index, value, setWpIds)
+                                    }
+                                />
+                            </div>
                         );
                     })}
-                </div>
+                </StyledFieldBox>
             </div>
-
             <CustomDialog
                 open={isOpen.wpId}
                 fullWidth={true}
@@ -95,31 +106,37 @@ export const FormContent = () => {
                 {wpIds.map((wpId, index) => {
                     const fieldName = `wpId[${index}]`;
                     return (
-                        <WpId
-                            key={index}
-                            wpId={wpId}
-                            fieldName={fieldName}
-                            onChange={(value: string) =>
-                                handleChange(wpIds, index, value, setWpIds)
-                            }
-                        />
+                        <div key={index}>
+                            <WpId
+                                wpId={wpId}
+                                fieldName={fieldName}
+                                onChange={(value: string) =>
+                                    handleChange(wpIds, index, value, setWpIds)
+                                }
+                            />
+                        </div>
                     );
                 })}
             </CustomDialog>
-            <div>
-                <LabelContainer>
+            <StyledLabelContainer>
+                <StyledIconContainer>
                     <label>
                         <strong>Serial numbers</strong>
                     </label>
                     <Edit onClick={() => setIsOpen((prev) => ({ ...prev, serialNumber: true }))} />
-                </LabelContainer>
+                </StyledIconContainer>
 
-                <div style={{ display: 'flex', gap: '10px' }}>
-                    {serialNumbers.map((serialNumber, index) => {
-                        const fieldName = `serialNumber[${index}]`;
-                        return (
+                <ErrorMessage
+                    name={`serialNumber[${0}]`}
+                    render={({ message }) => <StyledErrorP>{message}</StyledErrorP>}
+                />
+            </StyledLabelContainer>
+            <StyledFieldBox>
+                {serialNumbers.map((serialNumber, index) => {
+                    const fieldName = `serialNumber[${index}]`;
+                    return (
+                        <div key={index}>
                             <SerialNumber
-                                key={index}
                                 serialNumber={serialNumber}
                                 fieldName={fieldName}
                                 isPlainText
@@ -127,10 +144,10 @@ export const FormContent = () => {
                                     handleChange(serialNumbers, index, value, setSerialNumbers)
                                 }
                             />
-                        );
-                    })}
-                </div>
-            </div>
+                        </div>
+                    );
+                })}
+            </StyledFieldBox>
 
             <ProductNumber />
             <Revision />
@@ -152,18 +169,20 @@ export const FormContent = () => {
                 CancelButtonOnClick={() => setIsOpen((prev) => ({ ...prev, serialNumber: false }))}
                 SubmitButtonOnClick={() => setIsOpen((prev) => ({ ...prev, serialNumber: false }))}
             >
+                {' '}
                 {serialNumbers.map((serialNumber, index) => {
                     const fieldName = `serialNumber[${index}]`;
                     return (
-                        <SerialNumber
-                            key={index}
-                            serialNumber={serialNumber}
-                            fieldName={fieldName}
-                            isPlainText={false}
-                            onChange={(value: string) =>
-                                handleChange(serialNumbers, index, value, setSerialNumbers)
-                            }
-                        />
+                        <div key={index}>
+                            <SerialNumber
+                                serialNumber={serialNumber}
+                                fieldName={fieldName}
+                                isPlainText={false}
+                                onChange={(value: string) =>
+                                    handleChange(serialNumbers, index, value, setSerialNumbers)
+                                }
+                            />{' '}
+                        </div>
                     );
                 })}
             </CustomDialog>

--- a/src/pages/addItem/addItemForm/FormContent.tsx
+++ b/src/pages/addItem/addItemForm/FormContent.tsx
@@ -13,15 +13,12 @@ import { SerialNumber } from '../../../components/AddItemFormFields/SerialNumber
 import { Type } from '../../../components/AddItemFormFields/TemplateTypes/TemplateTypes';
 import { Vendor } from '../../../components/AddItemFormFields/Vendor/Vendor';
 import { WpId } from '../../../components/AddItemFormFields/WpId/WpId';
-import { StyledErrorP } from '../../../components/AddItemFormFields/styles';
+import { ScrollWrapContainer, StyledErrorP } from '../../../components/AddItemFormFields/styles';
 import { CustomDialog } from '../../../components/CustomDialog/CustomDialog';
 import AppContext from '../../../contexts/AppContext';
 import { Edit } from '../../itemDetails/itemInfo/styles';
 import { ItemSchema } from '../hooks/itemValidator';
-
 import { StyledIconContainer, StyledLabelContainer } from './styles';
-
-import { ScrollWrapContainer } from '../../../components/AddItemFormFields/styles';
 
 export const FormContent = () => {
     const { currentUser } = useContext(AppContext);
@@ -71,7 +68,6 @@ export const FormContent = () => {
                         </label>
                         <Edit onClick={() => setIsOpen((prev) => ({ ...prev, wpId: true }))} />
                     </StyledIconContainer>
-
                     <ErrorMessage
                         name={`wpId[${0}]`}
                         as="span"
@@ -127,13 +123,11 @@ export const FormContent = () => {
                     </label>
                     <Edit onClick={() => setIsOpen((prev) => ({ ...prev, serialNumber: true }))} />
                 </StyledIconContainer>
-
                 <ErrorMessage
                     name={`serialNumber[${0}]`}
                     render={({ message }) => <StyledErrorP>{message}</StyledErrorP>}
                 />
             </StyledLabelContainer>
-
             <ScrollWrapContainer>
                 {serialNumbers.map((serialNumber, index) => {
                     const fieldName = `serialNumber[${index}]`;
@@ -150,7 +144,6 @@ export const FormContent = () => {
                     );
                 })}
             </ScrollWrapContainer>
-
             <ProductNumber />
             <Revision />
             <Vendor />
@@ -171,7 +164,6 @@ export const FormContent = () => {
                 CancelButtonOnClick={() => setIsOpen((prev) => ({ ...prev, serialNumber: false }))}
                 SubmitButtonOnClick={() => setIsOpen((prev) => ({ ...prev, serialNumber: false }))}
             >
-                {' '}
                 {serialNumbers.map((serialNumber, index) => {
                     const fieldName = `serialNumber[${index}]`;
                     return (
@@ -183,7 +175,7 @@ export const FormContent = () => {
                                 onChange={(value: string) =>
                                     handleChange(serialNumbers, index, value, setSerialNumbers)
                                 }
-                            />{' '}
+                            />
                         </div>
                     );
                 })}

--- a/src/pages/addItem/addItemForm/FormContent.tsx
+++ b/src/pages/addItem/addItemForm/FormContent.tsx
@@ -19,10 +19,9 @@ import AppContext from '../../../contexts/AppContext';
 import { Edit } from '../../itemDetails/itemInfo/styles';
 import { ItemSchema } from '../hooks/itemValidator';
 
-import { StyledFieldBox, StyledIconContainer, StyledLabelContainer } from './styles';
+import { StyledIconContainer, StyledLabelContainer } from './styles';
 
 import { ScrollWrapContainer } from '../../../components/AddItemFormFields/styles';
-
 
 export const FormContent = () => {
     const { currentUser } = useContext(AppContext);
@@ -65,7 +64,6 @@ export const FormContent = () => {
             <Type />
             <Category />
             <div>
-
                 <StyledLabelContainer>
                     <StyledIconContainer>
                         <label>
@@ -80,37 +78,25 @@ export const FormContent = () => {
                         render={({ message }) => <StyledErrorP>{message}</StyledErrorP>}
                     />
                 </StyledLabelContainer>
-                <StyledFieldBox>
 
-                <LabelContainer>
-                    <label>
-                        <strong>WP ids</strong>
-                    </label>
-                    <Edit onClick={() => setIsOpen((prev) => ({ ...prev, wpId: true }))} />
-                </LabelContainer>
                 <ScrollWrapContainer>
-
                     {wpIds.map((wpId, index) => {
                         const fieldName = `wpId[${index}]`;
                         return (
-                            <div key={index}>
-                                <WpId
-                                    wpId={wpId}
-                                    fieldName={fieldName}
-                                    isPlainText
-                                    onChange={(value: string) =>
-                                        handleChange(wpIds, index, value, setWpIds)
-                                    }
-                                />
-                            </div>
+                            <WpId
+                                key={index}
+                                wpId={wpId}
+                                fieldName={fieldName}
+                                isPlainText
+                                onChange={(value: string) =>
+                                    handleChange(wpIds, index, value, setWpIds)
+                                }
+                            />
                         );
                     })}
-
-                </StyledFieldBox>
-
                 </ScrollWrapContainer>
-
             </div>
+
             <CustomDialog
                 open={isOpen.wpId}
                 fullWidth={true}
@@ -142,42 +128,28 @@ export const FormContent = () => {
                     <Edit onClick={() => setIsOpen((prev) => ({ ...prev, serialNumber: true }))} />
                 </StyledIconContainer>
 
-
                 <ErrorMessage
                     name={`serialNumber[${0}]`}
                     render={({ message }) => <StyledErrorP>{message}</StyledErrorP>}
                 />
             </StyledLabelContainer>
-            <StyledFieldBox>
+
+            <ScrollWrapContainer>
                 {serialNumbers.map((serialNumber, index) => {
                     const fieldName = `serialNumber[${index}]`;
                     return (
-                        <div key={index}>
-
-                <ScrollWrapContainer>
-                    {serialNumbers.map((serialNumber, index) => {
-                        const fieldName = `serialNumber[${index}]`;
-                        return (
-
-                            <SerialNumber
-                                serialNumber={serialNumber}
-                                fieldName={fieldName}
-                                isPlainText
-                                onChange={(value: string) =>
-                                    handleChange(serialNumbers, index, value, setSerialNumbers)
-                                }
-                            />
-
-                        </div>
+                        <SerialNumber
+                            key={index}
+                            serialNumber={serialNumber}
+                            fieldName={fieldName}
+                            isPlainText
+                            onChange={(value: string) =>
+                                handleChange(serialNumbers, index, value, setSerialNumbers)
+                            }
+                        />
                     );
                 })}
-            </StyledFieldBox>
-
-                        );
-                    })}
-                </ScrollWrapContainer>
-            </div>
-
+            </ScrollWrapContainer>
 
             <ProductNumber />
             <Revision />

--- a/src/pages/addItem/addItemForm/styles.ts
+++ b/src/pages/addItem/addItemForm/styles.ts
@@ -10,3 +10,24 @@ export const StyledForm = styled.form`
         box-sizing: border-box;
     }
 `;
+
+export const StyledLabelContainer = styled.div`
+    display: flex;
+    align-items: center;
+    width: 100%;
+
+    gap: 10px;
+    white-space: nowrap;
+`;
+export const StyledIconContainer = styled.div`
+    display: inline-flex;
+    justify-content: baseline;
+    gap: 10px;
+    word-break: keep-all;
+    white-space: nowrap;
+`;
+
+export const StyledFieldBox = styled.div`
+    display: flex;
+    gap: 10px;
+`;

--- a/src/pages/addItem/hooks/itemValidator.ts
+++ b/src/pages/addItem/hooks/itemValidator.ts
@@ -9,8 +9,8 @@ const templateSchema = z.object({
             name: z.string(),
         })
         .nullish(),
-    type: z.string().min(1, 'type is required'),
-    categoryId: z.string().min(1, 'category is required'),
+    type: z.string().min(1, 'Type is required'),
+    categoryId: z.string().min(1, 'Category is required'),
     productNumber: z.string().min(1, 'Product number is required'),
     description: z.string().min(1, 'Description is required'),
     createdById: z.string(),
@@ -20,8 +20,8 @@ const templateSchema = z.object({
 export const itemSchema = z.object({
     itemTemplate: templateSchema,
     itemTemplateId: z.string(),
-    wpId: z.array(z.string()),
-    serialNumber: z.array(z.string()),
+    wpId: z.array(z.string().min(1, 'WpId is required')),
+    serialNumber: z.array(z.string().min(1, 'Serial number is required')),
     vendorId: z.string().min(1, 'Vendor is required'),
     comment: z.string().nullish(),
     isBatch: z.boolean(),
@@ -44,6 +44,7 @@ export const itemSchema = z.object({
     locationId: z.string().min(1, 'Location is required'),
     parentId: z.string().nullish(),
     createdById: z.string().min(1),
+
     uniqueWpId: z.boolean().refine((data) => data, {}),
     uniqueSerialNumber: z.boolean().refine((data) => data, {}),
     files: z.array(z.instanceof(File)).nullish(),

--- a/src/pages/addItem/hooks/itemValidator.ts
+++ b/src/pages/addItem/hooks/itemValidator.ts
@@ -44,7 +44,6 @@ export const itemSchema = z.object({
     locationId: z.string().min(1, 'Location is required'),
     parentId: z.string().nullish(),
     createdById: z.string().min(1),
-
     uniqueWpId: z.boolean().refine((data) => data, {}),
     uniqueSerialNumber: z.boolean().refine((data) => data, {}),
     files: z.array(z.instanceof(File)).nullish(),

--- a/src/pages/addItem/hooks/useAddItemForm.ts
+++ b/src/pages/addItem/hooks/useAddItemForm.ts
@@ -46,7 +46,6 @@ export const useAddItemForm = () => {
         resolver: zodResolver(itemSchema),
         defaultValues: {
             ...defaultValues,
-
             createdById: currentUser?.id ?? '',
         },
     });
@@ -183,7 +182,6 @@ export const useAddItemForm = () => {
         resetField,
         templateSubmit,
         onchange,
-
         watch,
     };
 };

--- a/src/pages/addItem/hooks/useAddItemForm.ts
+++ b/src/pages/addItem/hooks/useAddItemForm.ts
@@ -42,9 +42,11 @@ export const useAddItemForm = () => {
     const appLocation = useLocation();
 
     const methods = useForm<ItemSchema>({
+        mode: 'onChange',
         resolver: zodResolver(itemSchema),
         defaultValues: {
             ...defaultValues,
+
             createdById: currentUser?.id ?? '',
         },
     });
@@ -180,6 +182,8 @@ export const useAddItemForm = () => {
         setValue,
         resetField,
         templateSubmit,
+        onchange,
+
         watch,
     };
 };

--- a/src/pages/itemDetails/itemInfo/styles.ts
+++ b/src/pages/itemDetails/itemInfo/styles.ts
@@ -1,7 +1,7 @@
 import EditIcon from '@mui/icons-material/Edit';
+import { TextField } from '@mui/material';
 import styled from 'styled-components';
 import { COLORS } from '../../../style/GlobalStyles';
-import { TextField } from '@mui/material';
 
 export const ItemInfoForm = styled.form`
     display: flex;


### PR DESCRIPTION
## Pull Request Summary

### What is missing from the codebase?

Currently, problems with form when refreshing, and no errormessage if wpId and serialNumber is left empty.

### Changes made in this pull request:
- added windows refresh warning box and resetting the form/navigating to start if refreshed.
- added validation / error messages for wpId and serialNumber
- zod validation fixes
- styling fixes


## Checklist

-   [x] **Review**: Have you reviewed your own changes to ensure they align with best practices?
