### PR TITLE
fix: update property to createdById

### DIFF
--- a/src/pages/admin/hooks/categoryValidator.ts
+++ b/src/pages/admin/hooks/categoryValidator.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 
 export const categorySchema = z.object({
     name: z.string().min(1, 'Category name is required'),
-    addedById: z.string().min(1),
+    createdById: z.string().min(1),
 });
 
 export type CategorySchema = z.infer<typeof categorySchema>;

--- a/src/pages/admin/hooks/locationValidator.ts
+++ b/src/pages/admin/hooks/locationValidator.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 
 export const locationSchema = z.object({
     name: z.string().min(1, 'Location name is required'),
-    addedById: z.string().min(1),
+    createdById: z.string().min(1),
 });
 
 export type LocationSchema = z.infer<typeof locationSchema>;

--- a/src/pages/admin/hooks/useAddCategoryForm.tsx
+++ b/src/pages/admin/hooks/useAddCategoryForm.tsx
@@ -8,7 +8,7 @@ import { CategorySchema, categorySchema } from './categoryValidator';
 
 const defaultValues: CategorySchema = {
     name: '',
-    addedById: '',
+    createdById: '',
 };
 
 export const useAddCategoryForm = () => {
@@ -20,7 +20,7 @@ export const useAddCategoryForm = () => {
         resolver: zodResolver(categorySchema),
         defaultValues: {
             ...defaultValues,
-            addedById: currentUser?.id ?? '',
+            createdById: currentUser?.id ?? '',
         },
     });
     const { handleSubmit, control, reset, resetField, register } = methods;

--- a/src/pages/admin/hooks/useAddLocationForm.tsx
+++ b/src/pages/admin/hooks/useAddLocationForm.tsx
@@ -8,7 +8,7 @@ import { LocationSchema, locationSchema } from './locationValidator';
 
 const defaultValues: LocationSchema = {
     name: '',
-    addedById: '',
+    createdById: '',
 };
 
 export const useAddLocationForm = () => {
@@ -20,7 +20,7 @@ export const useAddLocationForm = () => {
         resolver: zodResolver(locationSchema),
         defaultValues: {
             ...defaultValues,
-            addedById: currentUser?.id ?? '',
+            createdById: currentUser?.id ?? '',
         },
     });
     const { handleSubmit, control, reset, resetField, register } = methods;

--- a/src/pages/admin/hooks/useAddVendorForm.tsx
+++ b/src/pages/admin/hooks/useAddVendorForm.tsx
@@ -8,7 +8,7 @@ import { VendorSchema, vendorSchema } from './vendorValidator';
 
 const defaultValues: VendorSchema = {
     name: '',
-    addedById: '',
+    createdById: '',
 };
 
 export const useAddVendorForm = () => {
@@ -20,7 +20,7 @@ export const useAddVendorForm = () => {
         resolver: zodResolver(vendorSchema),
         defaultValues: {
             ...defaultValues,
-            addedById: currentUser?.id ?? '',
+            createdById: currentUser?.id ?? '',
         },
     });
     const { handleSubmit, control, reset, resetField, register } = methods;

--- a/src/pages/admin/hooks/vendorValidator.ts
+++ b/src/pages/admin/hooks/vendorValidator.ts
@@ -3,7 +3,7 @@ import { categorySchema } from './categoryValidator';
 
 export const vendorSchema = z.object({
     name: z.string().min(1, 'Vendor name is required'),
-    addedById: z.string().min(1),
+    createdById: z.string().min(1),
 });
 
 export type VendorSchema = z.infer<typeof categorySchema>;

--- a/src/services/apiTypes.ts
+++ b/src/services/apiTypes.ts
@@ -130,7 +130,7 @@ export type Vendor = {
 
 export type AddVendor = {
     name: string;
-    addedById: string;
+    createdById: string;
 };
 
 export type UpdateVendor = {
@@ -140,7 +140,7 @@ export type UpdateVendor = {
 
 export type AddLocation = {
     name: string;
-    addedById: string;
+    createdById: string;
 };
 
 export type UpdateLocation = {
@@ -155,7 +155,7 @@ export type Category = {
 
 export type AddCategory = {
     name: string;
-    addedById: string;
+    createdById: string;
 };
 
 export type UpdateCategory = {


### PR DESCRIPTION
## Pull Request Summary

### What is missing from the codebase?

Currently, the request to update location etc.. is being sent with property `addedById`

### Changes made in this pull request:

- updated property `addedById` to `createdById`

## Checklist

-   [x] **Review**: Have you reviewed your own changes to ensure they align with best practices?
