### PR TITLE
chore: change to named exports `{ ... }`

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,32 +8,31 @@ import {
     createBrowserRouter,
     createRoutesFromElements,
 } from 'react-router-dom';
-import ResponsiveRoute from './components/ResponsiveRoute/ResponsiveRoute';
+import { ResponsiveRoute } from './components/ResponsiveRoute/ResponsiveRoute';
 import { Snackbar } from './components/Snackbar/Snackbar';
-import ResponsiveAppBar from './components/TopBar/ResponsiveAppBar';
+import { ResponsiveAppBar } from './components/TopBar/ResponsiveAppBar';
 import { AppContextProvider } from './contexts/AppContext';
 import { useWindowDimensions } from './hooks/useWindowDimensions';
-import AddItem from './pages/addItem/Index';
+import { AddItem } from './pages/addItem/Index';
 import { AddItemForm } from './pages/addItem/addItemForm/AddItemForm';
-import BatchForm from './pages/addItem/batch/BatchForm';
-import CheckForm from './pages/addItem/check/CheckForm';
-import Upload from './pages/addItem/documentation/Upload';
-import RecentlyAdded from './pages/addItem/recentlyAdded/RecentlyAdded';
-import Template from './pages/addItem/template/Template';
-import AddCategory from './pages/admin/category/AddCategory';
-import Categories from './pages/admin/category/Categories';
-import AddLocation from './pages/admin/location/AddLocation';
-import Locations from './pages/admin/location/Locations';
-import AddVendor from './pages/admin/vendor/AddVendor';
-import Vendors from './pages/admin/vendor/Vendors';
-import ItemDetails from './pages/itemDetails/Index';
-import MakeList from './pages/list/MakeList';
-import ListDetails from './pages/listDetails/ListDetails';
-import Index from './pages/listDetails/phone/Tabs';
+import { BatchForm } from './pages/addItem/batch/BatchForm';
+import { CheckForm } from './pages/addItem/check/CheckForm';
+import { Upload } from './pages/addItem/documentation/Upload';
+import { RecentlyAdded } from './pages/addItem/recentlyAdded/RecentlyAdded';
+import { Template } from './pages/addItem/template/Template';
+import { AddCategory } from './pages/admin/category/AddCategory';
+import { Categories } from './pages/admin/category/Categories';
+import { AddLocation } from './pages/admin/location/AddLocation';
+import { Locations } from './pages/admin/location/Locations';
+import { AddVendor } from './pages/admin/vendor/AddVendor';
+import { Vendors } from './pages/admin/vendor/Vendors';
+import { ItemDetails } from './pages/itemDetails/Index';
+import { MakeList } from './pages/list/MakeList';
+import { ListDetails } from './pages/listDetails/ListDetails';
+import { Tabs } from './pages/listDetails/phone/Tabs';
 import { Login } from './pages/login/Login';
-import Search from './pages/search/Search';
+import { Search } from './pages/search/Search';
 import GlobalStyles, { globalTheme } from './style/GlobalStyles';
-import React from 'react';
 import { AddTemplate } from './pages/admin/template/AddTemplate';
 
 function App() {
@@ -64,7 +63,7 @@ function App() {
                     element={
                         <ResponsiveRoute
                             desktopElement={<ListDetails />}
-                            mobileElement={<Index />}
+                            mobileElement={<Tabs />}
                         />
                     }
                 />

--- a/src/components/AdminSearchCard/AdminSearchCard.tsx
+++ b/src/components/AdminSearchCard/AdminSearchCard.tsx
@@ -28,7 +28,7 @@ type Props = {
     searchType: SearchType;
 };
 
-const AdminSearchCard = ({ data, searchType }: Props) => {
+export const AdminSearchCard = ({ data, searchType }: Props) => {
     const { setSnackbarText, setSnackbarSeverity } = useContext(AppContext);
     const [isEditing, setIsEditing] = useState(false);
     const [isOpen, setIsOpen] = useState(false);
@@ -179,5 +179,3 @@ const AdminSearchCard = ({ data, searchType }: Props) => {
         </StyledAdminSearchCardContainer>
     );
 };
-
-export default AdminSearchCard;

--- a/src/components/File/File.tsx
+++ b/src/components/File/File.tsx
@@ -16,7 +16,7 @@ type FileProps = {
     handleFileRemoval: () => void;
 };
 
-const File = ({ doc, file, handleFileRemoval }: FileProps) => {
+export const File = ({ doc, file, handleFileRemoval }: FileProps) => {
     const handleFileDownload = (doc?: Document, file?: File) => {
         if (file) {
             const downloadLink = document.createElement('a');
@@ -77,5 +77,3 @@ const File = ({ doc, file, handleFileRemoval }: FileProps) => {
         </StyledFileWrapper>
     );
 };
-
-export default File;

--- a/src/components/ItemCard/ItemCard.stories.tsx
+++ b/src/components/ItemCard/ItemCard.stories.tsx
@@ -1,5 +1,5 @@
 import { Meta, StoryObj } from '@storybook/react';
-import ItemCard from './ItemCard';
+import { ItemCard } from './ItemCard';
 
 const meta = {
     title: 'Components/ItemCard',

--- a/src/components/ItemCard/ItemCard.tsx
+++ b/src/components/ItemCard/ItemCard.tsx
@@ -18,7 +18,7 @@ export type ItemCardProps = {
     icon?: string;
 };
 
-const ItemCard = ({ item, icon }: ItemCardProps) => {
+export const ItemCard = ({ item, icon }: ItemCardProps) => {
     const navigate = useNavigate();
     const location = useLocation();
 
@@ -40,5 +40,3 @@ const ItemCard = ({ item, icon }: ItemCardProps) => {
         </StyledItemCardContainer>
     );
 };
-
-export default ItemCard;

--- a/src/components/ItemCard/SearchInfoCompact/SearchInfoCompact.stories.tsx
+++ b/src/components/ItemCard/SearchInfoCompact/SearchInfoCompact.stories.tsx
@@ -1,11 +1,11 @@
 import { Meta, StoryObj } from '@storybook/react';
-import SearchInfoCompact from './SearchInfoCompact';
+import { SearchResultCardCompact } from './SearchInfoCompact';
 
 const meta = {
     title: 'Components/SearchInfoCompact',
-    component: SearchInfoCompact,
+    component: SearchResultCardCompact,
     tags: ['autodocs'],
-} as Meta<typeof SearchInfoCompact>;
+} as Meta<typeof SearchResultCardCompact>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;

--- a/src/components/ItemCard/SearchInfoCompact/SearchInfoCompact.tsx
+++ b/src/components/ItemCard/SearchInfoCompact/SearchInfoCompact.tsx
@@ -21,7 +21,7 @@ import {
     StyledItemCardCompactContainer,
 } from './styles';
 
-const SearchResultCardCompact = ({ item, icon }: ItemCardProps) => {
+export const SearchResultCardCompact = ({ item, icon }: ItemCardProps) => {
     const navigate = useNavigate();
     const { listId } = useParams();
     const {
@@ -118,5 +118,3 @@ const SearchResultCardCompact = ({ item, icon }: ItemCardProps) => {
         </>
     );
 };
-
-export default SearchResultCardCompact;

--- a/src/components/ProgressBar/ProgressBar.stories.tsx
+++ b/src/components/ProgressBar/ProgressBar.stories.tsx
@@ -1,5 +1,5 @@
 import { Meta, StoryObj } from '@storybook/react';
-import ProgressBar from './ProgressBar';
+import { ProgressBar } from './ProgressBar';
 
 const meta = {
     title: 'Components/ProgressBar',

--- a/src/components/ProgressBar/ProgressBar.tsx
+++ b/src/components/ProgressBar/ProgressBar.tsx
@@ -7,7 +7,7 @@ type ProgressBarProps = {
     steps: { fields: stepsSchema[]; slug: string }[];
 };
 
-const ProgressBar: React.FC<ProgressBarProps> = ({ activeStep, steps }) => {
+export const ProgressBar: React.FC<ProgressBarProps> = ({ activeStep, steps }) => {
     return (
         <>
             <Stepper activeStep={activeStep} alternativeLabel>
@@ -20,5 +20,3 @@ const ProgressBar: React.FC<ProgressBarProps> = ({ activeStep, steps }) => {
         </>
     );
 };
-
-export default ProgressBar;

--- a/src/components/ResponsiveRoute/ResponsiveRoute.tsx
+++ b/src/components/ResponsiveRoute/ResponsiveRoute.tsx
@@ -5,10 +5,11 @@ interface ResponsiveRouteProps {
     mobileElement: React.ReactNode;
 }
 
-const ResponsiveRoute: React.FC<ResponsiveRouteProps> = ({ desktopElement, mobileElement }) => {
+export const ResponsiveRoute: React.FC<ResponsiveRouteProps> = ({
+    desktopElement,
+    mobileElement,
+}) => {
     const { width } = useWindowDimensions();
 
     return width > 800 ? desktopElement : mobileElement;
 };
-
-export default ResponsiveRoute;

--- a/src/components/ResultSearchCard/ResultSearchCard.tsx
+++ b/src/components/ResultSearchCard/ResultSearchCard.tsx
@@ -9,7 +9,7 @@ type Props = {
     icon?: string;
 };
 
-const SearchResultCard = ({ item, icon }: Props) => {
+export const SearchResultCard = ({ item, icon }: Props) => {
     const navigate = useNavigate();
 
     return (
@@ -29,5 +29,3 @@ const SearchResultCard = ({ item, icon }: Props) => {
         </>
     );
 };
-
-export default SearchResultCard;

--- a/src/components/SearchBar/SearchBar.stories.tsx
+++ b/src/components/SearchBar/SearchBar.stories.tsx
@@ -1,5 +1,5 @@
 import { Meta, StoryObj } from '@storybook/react';
-import SearchBar from './SearchBar';
+import { SearchBar } from './SearchBar';
 
 const meta = {
     title: 'Components/SearchBar',

--- a/src/components/SearchBar/SearchBar.tsx
+++ b/src/components/SearchBar/SearchBar.tsx
@@ -8,7 +8,7 @@ type Props = {
     placeholder: string;
 };
 
-const SearchBar = ({ setSearchTerm, searchTerm, placeholder }: Props) => {
+export const SearchBar = ({ setSearchTerm, searchTerm, placeholder }: Props) => {
     const { width } = useWindowDimensions();
 
     return (
@@ -28,5 +28,3 @@ const SearchBar = ({ setSearchTerm, searchTerm, placeholder }: Props) => {
         </>
     );
 };
-
-export default SearchBar;

--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -18,7 +18,7 @@ interface Tab {
 interface TabBarProps {
     tabs: Tab[];
 }
-export default function TabComponent({ tabs }: TabBarProps) {
+export function TabComponent({ tabs }: TabBarProps) {
     const [activeTab, setActiveTab] = useState<number>(0);
     const { listId } = useParams();
 

--- a/src/components/TopBar/HamburgerMenu/HamburgerMenu.tsx
+++ b/src/components/TopBar/HamburgerMenu/HamburgerMenu.tsx
@@ -9,7 +9,7 @@ import SearchIcon from '@mui/icons-material/Search';
 import { Divider, List, ListItem, ListItemButton, ListItemIcon, ListItemText } from '@mui/material';
 import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import useNavigationControl from '../hooks/useNavigation';
+import { useNavigationControl } from '../hooks/useNavigation';
 import { DropdownItem, HamburgerContainer } from './styles';
 import NoteAddIcon from '@mui/icons-material/NoteAdd';
 type Props = {

--- a/src/components/TopBar/ResponsiveAppBar.tsx
+++ b/src/components/TopBar/ResponsiveAppBar.tsx
@@ -15,7 +15,7 @@ import { useState } from 'react';
 import { NavLink, Outlet, useLocation, useNavigate } from 'react-router-dom';
 import { useWindowDimensions } from '../../hooks';
 import { HamburgerMenu } from './HamburgerMenu/HamburgerMenu';
-import useNavigationControl from './hooks/useNavigation';
+import { useNavigationControl } from './hooks/useNavigation';
 import { AdminMenu } from './styles';
 const pages = ['Find items', 'Add item', 'Make list'];
 
@@ -26,7 +26,7 @@ const settings = [
     { text: 'Templates', location: 'admin/add-template' },
 ];
 
-function ResponsiveAppBar() {
+export function ResponsiveAppBar() {
     const navigate = useNavigate();
     const [anchorElUser, setAnchorElUser] = React.useState<null | HTMLElement>(null);
     const [adminDropdownIsOpen, setAdminDropdownIsOpen] = useState(false);
@@ -200,4 +200,3 @@ function ResponsiveAppBar() {
         </>
     );
 }
-export default ResponsiveAppBar;

--- a/src/components/TopBar/TopBar.stories.tsx
+++ b/src/components/TopBar/TopBar.stories.tsx
@@ -1,5 +1,5 @@
 import { Meta, StoryObj } from '@storybook/react';
-import TopBar from './TopBar';
+import { TopBar } from './TopBar';
 
 const meta = {
     title: 'Components/TopBar',

--- a/src/components/TopBar/TopBar.tsx
+++ b/src/components/TopBar/TopBar.tsx
@@ -7,7 +7,7 @@ import { Outlet } from 'react-router-dom';
 import { useWindowDimensions } from '../../hooks';
 
 import { HamburgerMenu } from './HamburgerMenu/HamburgerMenu';
-import useNavigationControl from './hooks/useNavigation';
+import { useNavigationControl } from './hooks/useNavigation';
 import {
     CompactContainer,
     StyledBackButton,
@@ -142,5 +142,3 @@ export const TopBar = () => {
         </>
     );
 };
-
-export default TopBar;

--- a/src/components/TopBar/hooks/useNavigation.tsx
+++ b/src/components/TopBar/hooks/useNavigation.tsx
@@ -1,7 +1,7 @@
 import { useMsal } from '@azure/msal-react';
 import { useLocation, useNavigate, useParams } from 'react-router-dom';
 
-const useNavigationControl = () => {
+export const useNavigationControl = () => {
     const navigate = useNavigate();
     const location = useLocation();
     const { listId } = useParams();
@@ -45,5 +45,3 @@ const useNavigationControl = () => {
         handleSignOut,
     };
 };
-
-export default useNavigationControl;

--- a/src/components/Upload/AddItemUpload.stories.tsx
+++ b/src/components/Upload/AddItemUpload.stories.tsx
@@ -1,5 +1,5 @@
 import { Meta, StoryObj } from '@storybook/react';
-import AddItemUpload from './AddItemUpload';
+import { AddItemUpload } from './AddItemUpload';
 
 const meta = {
     title: 'components/AddItemUpload',

--- a/src/components/Upload/AddItemUpload.tsx
+++ b/src/components/Upload/AddItemUpload.tsx
@@ -3,9 +3,9 @@ import { ChangeEvent, useRef, useState } from 'react';
 import { useFormContext } from 'react-hook-form';
 import { COLORS } from '../../style/GlobalStyles';
 import { Button as SubmitButton } from '../Button/Button';
-import File from '../File/File';
+import { File } from '../File/File';
 
-const AddItemUpload = () => {
+export const AddItemUpload = () => {
     const { setValue, getValues } = useFormContext();
     const [files, setFiles] = useState<File[]>();
     const inputFile = useRef<HTMLInputElement | null>(null);
@@ -59,4 +59,3 @@ const AddItemUpload = () => {
         </Box>
     );
 };
-export default AddItemUpload;

--- a/src/components/Upload/Upload.tsx
+++ b/src/components/Upload/Upload.tsx
@@ -20,7 +20,7 @@ import { useGetDocumentTypes } from '../../services/hooks/documents/useGetDocume
 import { useGetDocumentsByItemId } from '../../services/hooks/documents/useGetDocumentsByItemId';
 import { useUploadDocumentToItem } from '../../services/hooks/documents/useUploadDocumentToItem';
 import { COLORS } from '../../style/GlobalStyles';
-import File from '../File/File';
+import { File } from '../File/File';
 
 type UploadProps = {
     itemId: string;

--- a/src/components/Upload/UploadMobile/AddItemUploadMobile.tsx
+++ b/src/components/Upload/UploadMobile/AddItemUploadMobile.tsx
@@ -3,10 +3,10 @@ import { Box } from '@mui/material';
 import { ChangeEvent, useEffect, useRef, useState } from 'react';
 import { useFormContext } from 'react-hook-form';
 import { Button as SubmitButton } from '../../Button/Button';
-import File from '../../File/File';
+import { File } from '../../File/File';
 import { Wrapper } from './styles';
 
-const AddItemUploadMobile = () => {
+export const AddItemUploadMobile = () => {
     const { setValue, getValues } = useFormContext();
     const [files, setFiles] = useState<File[]>();
     const inputFile = useRef<HTMLInputElement | null>(null);
@@ -88,4 +88,3 @@ const AddItemUploadMobile = () => {
         </>
     );
 };
-export default AddItemUploadMobile;

--- a/src/components/Upload/UploadMobile/UploadMobile.tsx
+++ b/src/components/Upload/UploadMobile/UploadMobile.tsx
@@ -20,13 +20,13 @@ import { Container, Wrapper } from './styles';
 import { Button as SubmitButton } from '../../Button/Button';
 import { useUploadDocumentToItem } from '../../../services/hooks/documents/useUploadDocumentToItem';
 import { useGetDocumentTypes } from '../../../services/hooks/documents/useGetDocumentTypes';
-import File from '../../File/File';
+import { File } from '../../File/File';
 
 type UploadProps = {
     itemId: string;
 };
 
-const UploadMobile = ({ itemId }: UploadProps) => {
+export const UploadMobile = ({ itemId }: UploadProps) => {
     const { data: documents } = useGetDocumentsByItemId(itemId);
     const { data: documentTypes } = useGetDocumentTypes();
     const { mutate: uploadDocumentToItem } = useUploadDocumentToItem(itemId);
@@ -170,4 +170,3 @@ const UploadMobile = ({ itemId }: UploadProps) => {
         </>
     );
 };
-export default UploadMobile;

--- a/src/pages/addItem/Index.tsx
+++ b/src/pages/addItem/Index.tsx
@@ -2,7 +2,7 @@ import { Button } from '@mui/material';
 import React, { useEffect } from 'react';
 import { FormProvider } from 'react-hook-form';
 import { Outlet, useNavigate } from 'react-router-dom';
-import ProgressBar from '../../components/ProgressBar/ProgressBar';
+import { ProgressBar } from '../../components/ProgressBar/ProgressBar';
 import { StyledForm } from './addItemForm/styles';
 import { ItemSchema } from './hooks/itemValidator';
 import { useAddItemForm } from './hooks/useAddItemForm';
@@ -33,7 +33,7 @@ const steps: { fields: stepsSchema[]; slug: string }[] = [
     },
 ];
 
-const AddItem = () => {
+export const AddItem = () => {
     const { methods, onSubmit, trigger, reset } = useAddItemForm();
     const navigate = useNavigate();
     const [activeStep, setActiveStep] = React.useState(0);
@@ -110,5 +110,3 @@ const AddItem = () => {
         </FormProvider>
     );
 };
-
-export default AddItem;

--- a/src/pages/addItem/batch/BatchForm.tsx
+++ b/src/pages/addItem/batch/BatchForm.tsx
@@ -7,7 +7,7 @@ import { ItemSchema } from '../hooks/itemValidator.ts';
 import { FormContainer } from '../styles.ts';
 import { RadioWrapper, StyledInput } from './styles.ts';
 
-const BatchForm = () => {
+export const BatchForm = () => {
     const { control, register, setValue } = useFormContext<ItemSchema>();
     const {
         field: { onChange, value },
@@ -77,5 +77,3 @@ const BatchForm = () => {
         </FormContainer>
     );
 };
-
-export default BatchForm;

--- a/src/pages/addItem/check/CheckForm.tsx
+++ b/src/pages/addItem/check/CheckForm.tsx
@@ -4,7 +4,7 @@ import { ItemSchema } from '../hooks/itemValidator';
 import { FormContainer } from '../styles';
 import { StyledLabelText, StyledTextArea } from './styles';
 
-const CheckForm = () => {
+export const CheckForm = () => {
     const { control, register } = useFormContext<ItemSchema>();
     const {
         field: { onChange, value },
@@ -38,5 +38,3 @@ const CheckForm = () => {
         </FormContainer>
     );
 };
-
-export default CheckForm;

--- a/src/pages/addItem/documentation/Upload.tsx
+++ b/src/pages/addItem/documentation/Upload.tsx
@@ -1,13 +1,13 @@
 import { useController, useFormContext } from 'react-hook-form';
-import AddItemUpload from '../../../components/Upload/AddItemUpload';
-import AddItemUploadMobile from '../../../components/Upload/UploadMobile/AddItemUploadMobile';
+import { AddItemUpload } from '../../../components/Upload/AddItemUpload';
+import { AddItemUploadMobile } from '../../../components/Upload/UploadMobile/AddItemUploadMobile';
 
 import { useWindowDimensions } from '../../../hooks/useWindowDimensions';
 import { RadioWrapper, StyledInput } from '../batch/styles';
 import { ItemSchema } from '../hooks/itemValidator';
 import { FormContainer } from '../styles';
 
-const Upload = () => {
+export const Upload = () => {
     const { width } = useWindowDimensions();
 
     const { control } = useFormContext<ItemSchema>();
@@ -49,5 +49,3 @@ const Upload = () => {
         </FormContainer>
     );
 };
-
-export default Upload;

--- a/src/pages/addItem/recentlyAdded/RecentlyAdded.tsx
+++ b/src/pages/addItem/recentlyAdded/RecentlyAdded.tsx
@@ -1,13 +1,13 @@
 import { useNavigate } from 'react-router-dom';
-import ItemCard from '../../../components/ItemCard/ItemCard';
-import SearchResultCardCompact from '../../../components/ItemCard/SearchInfoCompact/SearchInfoCompact';
+import { ItemCard } from '../../../components/ItemCard/ItemCard';
+import { SearchResultCardCompact } from '../../../components/ItemCard/SearchInfoCompact/SearchInfoCompact';
 import { useWindowDimensions } from '../../../hooks/useWindowDimensions';
 import { Item } from '../../../services/apiTypes';
 import { useGetItemsByUser } from '../../../services/hooks/items/useGetItemByUser';
 import { Container, CardContainer, RecentlyAddedContainer } from './styles';
 import { Button } from '@mui/material';
 
-const RecentlyAdded = () => {
+export const RecentlyAdded = () => {
     const { width } = useWindowDimensions();
 
     const { data: myItems = [] } = useGetItemsByUser();
@@ -34,5 +34,3 @@ const RecentlyAdded = () => {
         </RecentlyAddedContainer>
     );
 };
-
-export default RecentlyAdded;

--- a/src/pages/addItem/template/Template.tsx
+++ b/src/pages/addItem/template/Template.tsx
@@ -7,7 +7,7 @@ import { useGetItemTemplates } from '../../../services/hooks/template/useGetItem
 import { ItemSchema } from '../hooks/itemValidator';
 import { Container } from './styles';
 
-export default function Template() {
+export function Template() {
     const { data: templates = [] } = useGetItemTemplates();
     const { control, reset, watch, setValue } = useFormContext<ItemSchema>();
     const {

--- a/src/pages/admin/category/AddCategory.tsx
+++ b/src/pages/admin/category/AddCategory.tsx
@@ -11,7 +11,7 @@ import {
     SubmitButtonContainer,
 } from '../styles';
 
-const AddCategory = () => {
+export const AddCategory = () => {
     const { methods, onSubmit, register } = useAddCategoryForm();
     return (
         <FormProvider {...methods}>
@@ -43,5 +43,3 @@ const AddCategory = () => {
         </FormProvider>
     );
 };
-
-export default AddCategory;

--- a/src/pages/admin/category/Categories.tsx
+++ b/src/pages/admin/category/Categories.tsx
@@ -1,15 +1,15 @@
 import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useDebounce } from 'usehooks-ts';
-import AdminSearchCard from '../../../components/AdminSearchCard/AdminSearchCard';
+import { AdminSearchCard } from '../../../components/AdminSearchCard/AdminSearchCard';
 import { Button } from '../../../components/Button/Button';
-import SearchBar from '../../../components/SearchBar/SearchBar';
+import { SearchBar } from '../../../components/SearchBar/SearchBar';
 import { Category } from '../../../services/apiTypes';
 import { useGetCategories } from '../../../services/hooks/category/useGetCategories';
 import { SearchType } from '../../../utils/constant';
 import { AdminContainer, ButtonContainer, SearchResultContainer } from '../styles';
 
-const Categories = () => {
+export const Categories = () => {
     const [searchTerm, setSearchTerm] = useState<string>('');
     const debouncedSearchTerm = useDebounce(searchTerm, 500);
     const { data: initialData } = useGetCategories();
@@ -48,5 +48,3 @@ const Categories = () => {
         </AdminContainer>
     );
 };
-
-export default Categories;

--- a/src/pages/admin/location/AddLocation.tsx
+++ b/src/pages/admin/location/AddLocation.tsx
@@ -11,7 +11,7 @@ import {
     SubmitButtonContainer,
 } from '../styles';
 
-const AddLocation = () => {
+export const AddLocation = () => {
     const { methods, onSubmit, register } = useAddLocationForm();
     return (
         <FormProvider {...methods}>
@@ -43,5 +43,3 @@ const AddLocation = () => {
         </FormProvider>
     );
 };
-
-export default AddLocation;

--- a/src/pages/admin/location/Locations.tsx
+++ b/src/pages/admin/location/Locations.tsx
@@ -1,14 +1,14 @@
 import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useDebounce } from 'usehooks-ts';
-import AdminSearchCard from '../../../components/AdminSearchCard/AdminSearchCard';
+import { AdminSearchCard } from '../../../components/AdminSearchCard/AdminSearchCard';
 import { Button } from '../../../components/Button/Button';
-import SearchBar from '../../../components/SearchBar/SearchBar';
+import { SearchBar } from '../../../components/SearchBar/SearchBar';
 import { Location } from '../../../services/apiTypes';
 import { useGetLocations } from '../../../services/hooks/locations/useGetLocations';
 import { SearchType } from '../../../utils/constant';
 import { AdminContainer, ButtonContainer, SearchResultContainer } from '../styles';
-const Locations = () => {
+export const Locations = () => {
     const [searchTerm, setSearchTerm] = useState<string>('');
     const debouncedSearchTerm = useDebounce(searchTerm, 500);
     const { data: initialData } = useGetLocations();
@@ -47,5 +47,3 @@ const Locations = () => {
         </AdminContainer>
     );
 };
-
-export default Locations;

--- a/src/pages/admin/vendor/AddVendor.tsx
+++ b/src/pages/admin/vendor/AddVendor.tsx
@@ -11,7 +11,7 @@ import {
     SubmitButtonContainer,
 } from '../styles';
 
-const AddVendor = () => {
+export const AddVendor = () => {
     const { methods, onSubmit, register } = useAddVendorForm();
     return (
         <FormProvider {...methods}>
@@ -43,5 +43,3 @@ const AddVendor = () => {
         </FormProvider>
     );
 };
-
-export default AddVendor;

--- a/src/pages/admin/vendor/Vendors.tsx
+++ b/src/pages/admin/vendor/Vendors.tsx
@@ -1,15 +1,15 @@
 import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useDebounce } from 'usehooks-ts';
-import AdminSearchCard from '../../../components/AdminSearchCard/AdminSearchCard';
+import { AdminSearchCard } from '../../../components/AdminSearchCard/AdminSearchCard';
 import { Button } from '../../../components/Button/Button';
-import SearchBar from '../../../components/SearchBar/SearchBar';
+import { SearchBar } from '../../../components/SearchBar/SearchBar';
 import { Vendor } from '../../../services/apiTypes';
 import { useGetVendors } from '../../../services/hooks/vendor/useGetVendors';
 import { SearchType } from '../../../utils/constant';
 import { AdminContainer, ButtonContainer, SearchResultContainer } from '../styles';
 
-const Vendors = () => {
+export const Vendors = () => {
     const [searchTerm, setSearchTerm] = useState<string>('');
     const debouncedSearchTerm = useDebounce(searchTerm, 500);
     const { data: initialData } = useGetVendors();
@@ -48,5 +48,3 @@ const Vendors = () => {
         </AdminContainer>
     );
 };
-
-export default Vendors;

--- a/src/pages/itemDetails/Index.tsx
+++ b/src/pages/itemDetails/Index.tsx
@@ -5,7 +5,7 @@ import { useNavigate, useParams } from 'react-router-dom';
 import { CustomDialog } from '../../components/CustomDialog/CustomDialog';
 import { Comments } from '../../components/ItemDetails/CommentForm/CommentForm';
 import { ExampleUpload } from '../../components/Upload/Upload';
-import UploadMobile from '../../components/Upload/UploadMobile/UploadMobile';
+import { UploadMobile } from '../../components/Upload/UploadMobile/UploadMobile';
 import AppContext from '../../contexts/AppContext';
 import { useWindowDimensions } from '../../hooks';
 import { useDeleteItemById } from '../../services/hooks/items/useDeleteItemById';
@@ -13,11 +13,11 @@ import { useGetItemById } from '../../services/hooks/items/useGetItemById';
 import { ButtonContainer } from '../addItem/styles';
 import { Log } from './Log';
 import { Hierarchy } from './hierarchy';
-import ItemInfo from './itemInfo/ItemInfo';
+import { ItemInfo } from './itemInfo/ItemInfo';
 import { useUpdateItemForm } from './itemInfo/hooks/useUpdateItemForm';
 import { BreadcrumbLink, BreadcrumbsMargin, StyledContainerDiv } from './styles';
 
-const ItemDetails = () => {
+export const ItemDetails = () => {
     const { id } = useParams() as { id: string };
     const { data: item, isLoading } = useGetItemById(id);
     const { methods } = useUpdateItemForm(item!);
@@ -102,5 +102,3 @@ const ItemDetails = () => {
         </StyledContainerDiv>
     );
 };
-
-export default ItemDetails;

--- a/src/pages/itemDetails/itemInfo/EditableField.tsx
+++ b/src/pages/itemDetails/itemInfo/EditableField.tsx
@@ -29,7 +29,7 @@ type EditableFieldProps<TMultiLine = boolean> = {
       }
     : { isMultiLine?: false; rows?: never });
 
-const EditableField = ({
+export const EditableField = ({
     isMultiLine,
     label,
     onBlur,
@@ -113,5 +113,3 @@ const EditableField = ({
         </TextBoxWrap>
     );
 };
-
-export default EditableField;

--- a/src/pages/itemDetails/itemInfo/ItemInfo.tsx
+++ b/src/pages/itemDetails/itemInfo/ItemInfo.tsx
@@ -13,7 +13,7 @@ import { useGetItemTemplateById } from '../../../services/hooks/template/useGetI
 import { useUpdateItemTemplate } from '../../../services/hooks/template/useUpdateItemTemplate';
 import { useGetVendors } from '../../../services/hooks/vendor/useGetVendors';
 import { handleApiRequestSnackbar } from '../../../utils/handleApiRequestSnackbar';
-import EditableField from './EditableField';
+import { EditableField } from './EditableField';
 import { SelectField } from './SelectField';
 import { ItemInfoSchema } from './hooks';
 import { Container, CreatedByContainer, ItemInfoForm } from './styles';
@@ -31,7 +31,7 @@ type Field =
       }
     | string;
 
-const ItemInfo = ({ item, isLoading }: ItemInfoProps) => {
+export const ItemInfo = ({ item, isLoading }: ItemInfoProps) => {
     const {
         watch,
         setValue,
@@ -245,5 +245,3 @@ const ItemInfo = ({ item, isLoading }: ItemInfoProps) => {
         </ItemInfoForm>
     );
 };
-
-export default ItemInfo;

--- a/src/pages/list/MakeList.tsx
+++ b/src/pages/list/MakeList.tsx
@@ -5,7 +5,7 @@ import { useParams } from 'react-router-dom';
 import { CustomDialog } from '../../components/CustomDialog/CustomDialog';
 import { GlobalSpinner } from '../../components/GlobalSpinner/GlobalSpinner';
 import { ListCard } from '../../components/ListCard/ListCard';
-import SearchBar from '../../components/SearchBar/SearchBar';
+import { SearchBar } from '../../components/SearchBar/SearchBar';
 import AppContext from '../../contexts/AppContext';
 import { useWindowDimensions } from '../../hooks';
 import { Item, List } from '../../services/apiTypes';
@@ -14,7 +14,7 @@ import { useGetListsByUserId } from '../../services/hooks/list/useGetListsByUser
 import { SearchContainer } from '../search/styles';
 import { FlexWrapper, SearchAndButton } from './styles';
 
-const MakeList = () => {
+export const MakeList = () => {
     const { currentUser } = useContext(AppContext);
     const { searchParam } = useParams<{ searchParam: string }>();
     const [searchTerm, setSearchTerm] = useState('');
@@ -105,5 +105,3 @@ const MakeList = () => {
         </>
     );
 };
-
-export default MakeList;

--- a/src/pages/listDetails/ListDetails.tsx
+++ b/src/pages/listDetails/ListDetails.tsx
@@ -3,13 +3,13 @@ import { useNavigate, useParams } from 'react-router-dom';
 import { useDebounce } from 'usehooks-ts';
 import { Button } from '../../components/Button/Button';
 import { GlobalSpinner } from '../../components/GlobalSpinner/GlobalSpinner';
-import ItemCard from '../../components/ItemCard/ItemCard';
-import SearchResultCardCompact from '../../components/ItemCard/SearchInfoCompact/SearchInfoCompact';
-import SearchBar from '../../components/SearchBar/SearchBar';
+import { ItemCard } from '../../components/ItemCard/ItemCard';
+import { SearchResultCardCompact } from '../../components/ItemCard/SearchInfoCompact/SearchInfoCompact';
+import { SearchBar } from '../../components/SearchBar/SearchBar';
 import AppContext from '../../contexts/AppContext';
 import { useWindowDimensions } from '../../hooks';
 import { Item, UpdateList } from '../../services/apiTypes';
-import useExportToExcel from '../../services/hooks/export/useExportToExcel';
+import { useExportToExcel } from '../../services/hooks/export/useExportToExcel';
 import { useGetItemsInfinite } from '../../services/hooks/items/useGetItemsInfinite';
 import { useGetListById } from '../../services/hooks/list/useGetListById';
 import { useUpdateList } from '../../services/hooks/list/useUpdateList';
@@ -25,7 +25,7 @@ import {
     SearchResultsContainer,
 } from './styles';
 
-const ListDetails = () => {
+export const ListDetails = () => {
     const { setSnackbarText, setSnackbarSeverity } = useContext(AppContext);
     const { listId } = useParams();
     const [searchTerm, setSearchTerm] = useState('');
@@ -146,5 +146,3 @@ const ListDetails = () => {
         </>
     );
 };
-
-export default ListDetails;

--- a/src/pages/listDetails/phone/AddMore.tsx
+++ b/src/pages/listDetails/phone/AddMore.tsx
@@ -2,10 +2,10 @@ import { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { useDebounce } from 'usehooks-ts';
 import { GlobalSpinner } from '../../../components/GlobalSpinner/GlobalSpinner';
-import SearchResultCardCompact from '../../../components/ItemCard/SearchInfoCompact/SearchInfoCompact';
+import { SearchResultCardCompact } from '../../../components/ItemCard/SearchInfoCompact/SearchInfoCompact';
 
 import { Box } from '@mui/material';
-import SearchBar from '../../../components/SearchBar/SearchBar';
+import { SearchBar } from '../../../components/SearchBar/SearchBar';
 import { useGetItemsInfinite } from '../../../services/hooks/items/useGetItemsInfinite';
 import { useGetListById } from '../../../services/hooks/list/useGetListById';
 import { PhoneContainer, PhoneListTitle } from './styles';

--- a/src/pages/listDetails/phone/Tabs.tsx
+++ b/src/pages/listDetails/phone/Tabs.tsx
@@ -1,10 +1,10 @@
 import { useParams } from 'react-router';
-import TabComponent from '../../../components/Tabs/Tabs';
+import { TabComponent } from '../../../components/Tabs/Tabs';
 import { useGetListById } from '../../../services/hooks/list/useGetListById';
 import { AddMoreCompact } from './AddMore';
 import { PhoneList } from './list/PhoneList';
 
-const Tabs = () => {
+export const Tabs = () => {
     const { listId } = useParams();
     const { data: list } = useGetListById(listId!);
 
@@ -25,5 +25,3 @@ const Tabs = () => {
         </>
     );
 };
-
-export default Tabs;

--- a/src/pages/listDetails/phone/list/PhoneList.tsx
+++ b/src/pages/listDetails/phone/list/PhoneList.tsx
@@ -3,9 +3,7 @@ import { useNavigate, useParams } from 'react-router-dom';
 import { useDebounce } from 'usehooks-ts';
 import { Button } from '../../../../components/Button/Button';
 import { GlobalSpinner } from '../../../../components/GlobalSpinner/GlobalSpinner';
-
-import SearchResultCardCompact from '../../../../components/ItemCard/SearchInfoCompact/SearchInfoCompact';
-
+import { SearchResultCardCompact } from '../../../../components/ItemCard/SearchInfoCompact/SearchInfoCompact';
 import AppContext from '../../../../contexts/AppContext';
 import { Item, List, UpdateList } from '../../../../services/apiTypes';
 import { useGetItemsInfinite } from '../../../../services/hooks/items/useGetItemsInfinite';

--- a/src/pages/search/Search.tsx
+++ b/src/pages/search/Search.tsx
@@ -1,13 +1,13 @@
 import { useEffect, useState } from 'react';
 import { useLocation, useParams } from 'react-router-dom';
 import { useDebounce, useLocalStorage } from 'usehooks-ts';
-import SearchBar from '../../components/SearchBar/SearchBar';
+import { SearchBar } from '../../components/SearchBar/SearchBar';
 import { useWindowDimensions } from '../../hooks';
 
 import { GlobalSpinner } from '../../components/GlobalSpinner/GlobalSpinner';
 
-import ItemCard from '../../components/ItemCard/ItemCard';
-import SearchResultCardCompact from '../../components/ItemCard/SearchInfoCompact/SearchInfoCompact';
+import { ItemCard } from '../../components/ItemCard/ItemCard';
+import { SearchResultCardCompact } from '../../components/ItemCard/SearchInfoCompact/SearchInfoCompact';
 import { useGetItemsInfinite } from '../../services/hooks/items/useGetItemsInfinite';
 import {
     Container,
@@ -22,7 +22,7 @@ type StateType = {
     resetInputField?: boolean;
 };
 
-const Search = () => {
+export const Search = () => {
     const { searchParam } = useParams<{ searchParam: string }>();
     const [searchTerm, setSearchTerm] = useState('');
     const debouncedSearchTerm = useDebounce(searchTerm, 500);
@@ -128,5 +128,3 @@ const Search = () => {
         </>
     );
 };
-
-export default Search;

--- a/src/services/hooks/export/useExportToExcel.ts
+++ b/src/services/hooks/export/useExportToExcel.ts
@@ -17,7 +17,7 @@ type ExcelData = {
     location?: string;
 };
 
-const useExportToExcel = (): ExportToExcelHook => {
+export const useExportToExcel = (): ExportToExcelHook => {
     const exportToExcel = (items: Item[]) => {
         const data = processAndSetData(items);
         const wb = XLSX.utils.book_new();
@@ -43,5 +43,3 @@ const useExportToExcel = (): ExportToExcelHook => {
     };
     return { exportToExcel };
 };
-
-export default useExportToExcel;

--- a/src/utils/CheckRole.tsx
+++ b/src/utils/CheckRole.tsx
@@ -1,11 +1,9 @@
 import { User } from '../services/apiTypes';
 
-const CheckRole = ({ currentUser }: { currentUser: User | null }) => {
+export const CheckRole = ({ currentUser }: { currentUser: User | null }) => {
     const isInspector = () => currentUser?.userRole.name === 'Inspector' || false;
 
     return {
         isInspector,
     };
 };
-
-export default CheckRole;

--- a/tests/unit/components/SearchBar.test.tsx
+++ b/tests/unit/components/SearchBar.test.tsx
@@ -2,7 +2,7 @@ import { it, expect, describe, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
-import SearchBar from '../../../src/components/SearchBar/SearchBar';
+import { SearchBar } from '../../../src/components/SearchBar/SearchBar';
 
 describe('SearchBar Component', () => {
     it('renders the SearchBar component with the correct placeholder', () => {


### PR DESCRIPTION
## Pull Request Summary

### What is missing from the codebase?

Currently, some files are exported using default export

### Changes made in this pull request:

- changed every instance of export default to named export, except for some (stories, context, global styles etc..)

## Checklist

-   [x] **Review**: Have you reviewed your own changes to ensure they align with best practices?
