### PR TITLE
fix

### DIFF
--- a/src/components/AddItemFormFields/SerialNumbers/SerialNumbers.tsx
+++ b/src/components/AddItemFormFields/SerialNumbers/SerialNumbers.tsx
@@ -18,6 +18,24 @@ export const SerialNumbers = () => {
     const {
         field: { value, onChange },
     } = useController({ name: 'serialNumber', control });
+    const [oldSerialNumber, setOldSerialNumber] = useState(value);
+    const [serialNumbers, setSerialNumber] = useState(value);
+
+    const handleCancel = () => {
+        setIsOpen((prev) => !prev);
+        setSerialNumber(oldSerialNumber);
+    };
+    const handleChange = (newValue: string, index: number) => {
+        const newValues = [...value];
+        newValues[index] = newValue;
+        setSerialNumber(newValues);
+    };
+
+    const handleSave = () => {
+        onChange(serialNumbers);
+        setOldSerialNumber(serialNumbers);
+        setIsOpen((prev) => !prev);
+    };
     return (
         <>
             <div>
@@ -36,17 +54,13 @@ export const SerialNumbers = () => {
                 </StyledLabelContainer>
 
                 <ScrollWrapContainer>
-                    {value.map((serialNumber, index) => {
+                    {serialNumbers.map((serialNumber, index) => {
                         return (
                             <SerialNumber
                                 key={index}
                                 serialNumber={serialNumber}
                                 isPlainText
-                                onChange={(newValue: string) => {
-                                    const newValues = [...value];
-                                    newValues[index] = newValue;
-                                    onChange(newValues);
-                                }}
+                                onChange={(value) => handleChange(value, index)}
                             />
                         );
                     })}
@@ -57,19 +71,15 @@ export const SerialNumbers = () => {
                 fullWidth={true}
                 onClose={() => setIsOpen((prev) => !prev)}
                 title="Edit Serial number"
-                CancelButtonOnClick={() => setIsOpen((prev) => !prev)}
-                SubmitButtonOnClick={() => setIsOpen((prev) => !prev)}
+                CancelButtonOnClick={handleCancel}
+                SubmitButtonOnClick={handleSave}
             >
-                {value.map((serialNumber, index) => {
+                {serialNumbers.map((serialNumber, index) => {
                     return (
                         <div key={index}>
                             <SerialNumber
                                 serialNumber={serialNumber}
-                                onChange={(newValue: string) => {
-                                    const newValues = [...value];
-                                    newValues[index] = newValue;
-                                    onChange(newValues);
-                                }}
+                                onChange={(value) => handleChange(value, index)}
                             />
                         </div>
                     );

--- a/src/components/AddItemFormFields/WpIds/WpIds.tsx
+++ b/src/components/AddItemFormFields/WpIds/WpIds.tsx
@@ -19,6 +19,24 @@ export const WpIds = () => {
     const {
         field: { value, onChange },
     } = useController({ name: 'wpId', control });
+    const [oldWpIds, setOldWpIds] = useState(value);
+    const [wpIds, setWpIds] = useState(value);
+
+    const handleCancel = () => {
+        setIsOpen((prev) => !prev);
+        setWpIds(oldWpIds);
+    };
+    const handleChange = (newValue: string, index: number) => {
+        const newValues = [...value];
+        newValues[index] = newValue;
+        setWpIds(newValues);
+    };
+
+    const handleSave = () => {
+        onChange(wpIds);
+        setOldWpIds(wpIds);
+        setIsOpen((prev) => !prev);
+    };
     return (
         <>
             <div>
@@ -37,17 +55,13 @@ export const WpIds = () => {
                 </StyledLabelContainer>
 
                 <ScrollWrapContainer>
-                    {value.map((wpId, index) => {
+                    {wpIds.map((wpId, index) => {
                         return (
                             <WpId
-                                key={index}
+                                key={wpId}
                                 wpId={wpId}
                                 isPlainText
-                                onChange={(newValue: string) => {
-                                    const newValues = [...value];
-                                    newValues[index] = newValue;
-                                    onChange(newValues);
-                                }}
+                                onChange={(value) => handleChange(value, index)}
                             />
                         );
                     })}
@@ -58,20 +72,13 @@ export const WpIds = () => {
                 fullWidth={true}
                 onClose={() => setIsOpen((prev) => !prev)}
                 title="Edit WpIds"
-                CancelButtonOnClick={() => setIsOpen((prev) => !prev)}
-                SubmitButtonOnClick={() => setIsOpen((prev) => !prev)}
+                CancelButtonOnClick={handleCancel}
+                SubmitButtonOnClick={handleSave}
             >
-                {value.map((wpId, index) => {
+                {wpIds.map((wpId, index) => {
                     return (
                         <div key={index}>
-                            <WpId
-                                wpId={wpId}
-                                onChange={(newValue: string) => {
-                                    const newValues = [...value];
-                                    newValues[index] = newValue;
-                                    onChange(newValues);
-                                }}
-                            />
+                            <WpId wpId={wpId} onChange={(value) => handleChange(value, index)} />
                         </div>
                     );
                 })}

--- a/src/pages/addItem/Index.tsx
+++ b/src/pages/addItem/Index.tsx
@@ -51,18 +51,26 @@ export const AddItem = () => {
 
     useEffect(() => {
         steps.some((step) => {
-            if (!location.pathname.includes(`${step.slug}`)) {
+            if (!location.pathname.includes(`${step.slug}`) || location.pathname === '/add-item/') {
                 setActiveStep(0);
                 reset();
-            } else if (location.pathname === '/add-item/') {
-                setActiveStep(0);
             }
         });
     }, [!location.pathname.includes('/add-item/')]);
 
     useEffect(() => {
+        if (location.pathname === '/add-item/') {
+            setActiveStep(0);
+            reset();
+        }
+    }, [location.pathname]);
+
+    useEffect(() => {
         const currentStep = steps.findIndex((step) => location.pathname.includes(`${step.slug}`));
         setActiveStep(currentStep !== -1 ? currentStep : 0);
+        if (activeStep === 0) {
+            reset();
+        }
     }, [location.pathname]);
 
     useEffect(() => {

--- a/src/pages/addItem/addItemForm/FormContent.tsx
+++ b/src/pages/addItem/addItemForm/FormContent.tsx
@@ -1,7 +1,6 @@
 import { TextField } from '@mui/material';
-import { useContext, useEffect } from 'react';
+import { useContext } from 'react';
 import { useFormContext } from 'react-hook-form';
-import { v4 as uuid } from 'uuid';
 import { Category } from '../../../components/AddItemFormFields/Category/Category';
 import { Comment } from '../../../components/AddItemFormFields/Comment/Comment';
 import { Description } from '../../../components/AddItemFormFields/Description/Description';
@@ -17,17 +16,7 @@ import { ItemSchema } from '../hooks/itemValidator';
 
 export const FormContent = () => {
     const { currentUser } = useContext(AppContext);
-    const { register, watch, setValue } = useFormContext<ItemSchema>();
-    const numberOfItems = watch('numberOfItems');
-
-    useEffect(() => {
-        const uniqueWpIds = Array.from({ length: +numberOfItems }, () => uuid().slice(0, 8));
-        const uniqueSerialNumbers = Array.from({ length: +numberOfItems }, () =>
-            uuid().slice(0, 8)
-        );
-        setValue('wpId', uniqueWpIds);
-        setValue('serialNumber', uniqueSerialNumbers);
-    }, [numberOfItems]);
+    const { register } = useFormContext<ItemSchema>();
 
     return (
         <>

--- a/src/pages/addItem/batch/BatchForm.tsx
+++ b/src/pages/addItem/batch/BatchForm.tsx
@@ -1,28 +1,12 @@
 import { ErrorMessage } from '@hookform/error-message';
 import { TextField } from '@mui/material';
-import { useEffect } from 'react';
-import { useController, useFormContext } from 'react-hook-form';
 import { StyledErrorP } from '../../../components/AddItemFormFields/styles.ts';
-import { ItemSchema } from '../hooks/itemValidator.ts';
 import { FormContainer } from '../styles.ts';
+import { useBatchForm } from './hooks/useBatchForm.tsx';
 import { RadioWrapper, StyledInput } from './styles.ts';
 
 export const BatchForm = () => {
-    const { control, register, setValue } = useFormContext<ItemSchema>();
-    const {
-        field: { onChange, value },
-        fieldState: { error },
-    } = useController({
-        control,
-        name: 'isBatch',
-    });
-
-    useEffect(() => {
-        if (!value) {
-            setValue('numberOfItems', '1');
-        }
-    }, []);
-
+    const { isBatch, onChangeIsBatch, numberOfItemsField, error } = useBatchForm();
     return (
         <FormContainer>
             <h3>Add as a batch?</h3>
@@ -31,10 +15,10 @@ export const BatchForm = () => {
             <label>
                 <RadioWrapper>
                     <StyledInput
-                        checked={!value}
+                        checked={!isBatch}
                         type="radio"
                         name="batchCheck"
-                        onChange={() => onChange(false)}
+                        onChange={() => onChangeIsBatch(false)}
                     />
                     <p>I want to add one unique item</p>
                 </RadioWrapper>
@@ -42,10 +26,10 @@ export const BatchForm = () => {
             <label>
                 <RadioWrapper>
                     <StyledInput
-                        checked={value}
+                        checked={isBatch}
                         type="radio"
                         name="batchCheck"
-                        onChange={() => onChange(true)}
+                        onChange={() => onChangeIsBatch(true)}
                     />
                     <p>
                         I want to add a batch of several identical items, assigning a unique
@@ -53,7 +37,7 @@ export const BatchForm = () => {
                     </p>
                 </RadioWrapper>
             </label>
-            {value && (
+            {numberOfItemsField.value && (
                 <div style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
                     <label>
                         <strong>Number of items:</strong>
@@ -63,7 +47,7 @@ export const BatchForm = () => {
                         render={({ message }) => <StyledErrorP>{message}</StyledErrorP>}
                     />
                     <TextField
-                        {...register('numberOfItems')}
+                        {...numberOfItemsField}
                         type="number"
                         label="Amount"
                         size="small"

--- a/src/pages/addItem/batch/hooks/useBatchForm.tsx
+++ b/src/pages/addItem/batch/hooks/useBatchForm.tsx
@@ -4,7 +4,7 @@ import { v4 as uuid } from 'uuid';
 import { ItemSchema } from '../../hooks/itemValidator';
 
 export const useBatchForm = () => {
-    const { control, register, watch, setValue } = useFormContext<ItemSchema>();
+    const { control, setValue } = useFormContext<ItemSchema>();
     const {
         field: { onChange, value },
         fieldState: { error },

--- a/src/pages/addItem/batch/hooks/useBatchForm.tsx
+++ b/src/pages/addItem/batch/hooks/useBatchForm.tsx
@@ -1,0 +1,40 @@
+import { ChangeEvent } from 'react';
+import { useController, useFormContext } from 'react-hook-form';
+import { v4 as uuid } from 'uuid';
+import { ItemSchema } from '../../hooks/itemValidator';
+
+export const useBatchForm = () => {
+    const { control, register, watch, setValue } = useFormContext<ItemSchema>();
+    const {
+        field: { onChange, value },
+        fieldState: { error },
+    } = useController({
+        control,
+        name: 'isBatch',
+    });
+    const {
+        field: { onChange: onChangeNumberOfItems, ...rest },
+    } = useController({
+        control,
+        name: 'numberOfItems',
+    });
+    const handleOnNumberOfChangeItems = (e: ChangeEvent<HTMLTextAreaElement>) => {
+        onChangeNumberOfItems(e.target.value);
+        const uniqueWpIds = Array.from({ length: +e.target.value }, () => uuid().slice(0, 8));
+        const uniqueSerialNumbers = Array.from({ length: +e.target.value }, () =>
+            uuid().slice(0, 8)
+        );
+        setValue('wpId', uniqueWpIds);
+        setValue('serialNumber', uniqueSerialNumbers);
+    };
+
+    return {
+        isBatch: value,
+        onChangeIsBatch: onChange,
+        numberOfItemsField: {
+            onChange: handleOnNumberOfChangeItems,
+            ...rest,
+        },
+        error,
+    };
+};

--- a/src/pages/addItem/hooks/useAddItemForm.ts
+++ b/src/pages/addItem/hooks/useAddItemForm.ts
@@ -167,9 +167,6 @@ export const useAddItemForm = () => {
         (errors) => console.error(errors)
     );
 
-
-    
-
     const onSubmitTyped: (e?: React.BaseSyntheticEvent<object> | undefined) => Promise<void> =
         onSubmit;
     return {

--- a/src/pages/addItem/hooks/useAddItemForm.ts
+++ b/src/pages/addItem/hooks/useAddItemForm.ts
@@ -167,6 +167,9 @@ export const useAddItemForm = () => {
         (errors) => console.error(errors)
     );
 
+
+    
+
     const onSubmitTyped: (e?: React.BaseSyntheticEvent<object> | undefined) => Promise<void> =
         onSubmit;
     return {

--- a/src/pages/addItem/hooks/useAddItemForm.ts
+++ b/src/pages/addItem/hooks/useAddItemForm.ts
@@ -33,7 +33,7 @@ const defaultValues: ItemSchema = {
     preCheck: { check: false, comment: '' },
     documentation: false,
     itemTemplate: defaultTemplate,
-    numberOfItems: '',
+    numberOfItems: '1',
 };
 
 export const useAddItemForm = () => {
@@ -72,6 +72,7 @@ export const useAddItemForm = () => {
         if (selectedTemplate) {
             setValue('itemTemplate', selectedTemplate);
             setValue('itemTemplateId', selectedTemplate?.id);
+            setValue('itemTemplate.revision', selectedTemplate.revision || '');
         }
     }, []);
 

--- a/src/pages/itemDetails/itemInfo/ItemInfo.tsx
+++ b/src/pages/itemDetails/itemInfo/ItemInfo.tsx
@@ -91,7 +91,6 @@ export const ItemInfo = ({ item, isLoading }: ItemInfoProps) => {
                         {
                             ...itemTemplateData,
                             [field]: mutableValue,
-                            revision: 'test',
                         },
                         {
                             onSuccess: (data) => {


### PR DESCRIPTION
## Pull Request Summary

### What is missing from the codebase?

Currently, the WpId and serial number fields did not work as intended, and the cancel button did not cancel the changes made in the modal. the useffect in formcontent also made it so the batch did not work as intended. 

### Changes made in this pull request:

-added saved states to serial numbers and WpIds so it will remember the changes(old values and new values) you make if you click submit or cancel in the modal
- added Batch logic in its own hook
- removed 'test' from revision and added the proper revision endpoint
- fixed location pathname reset form function 

## Checklist

-   [x] **Review**: Have you reviewed your own changes to ensure they align with best practices?
