### PR TITLE
fixes

### DIFF
--- a/src/components/AddItemFormFields/SerialNumber/SerialNumber.tsx
+++ b/src/components/AddItemFormFields/SerialNumber/SerialNumber.tsx
@@ -12,6 +12,9 @@ import {
 } from '../styles.ts';
 
 import HelpOutlineIcon from '@mui/icons-material/HelpOutline';
+import { useEffect } from 'react';
+import { useFormContext } from 'react-hook-form';
+import { ItemSchema } from '../../../pages/addItem/hooks/itemValidator.ts';
 import { StyledParagraph } from '../WpId/styles.ts';
 
 type SerialNumberProps = {
@@ -21,7 +24,13 @@ type SerialNumberProps = {
 };
 export const SerialNumber = ({ serialNumber, onChange, isPlainText }: SerialNumberProps) => {
     const debouncedSerialNumber = useDebounce(serialNumber, 500);
-    const { data: isUnique, isLoading } = useIsSerialNumberUnique(debouncedSerialNumber!);
+    const { data: isUnique = true, isLoading } = useIsSerialNumberUnique(debouncedSerialNumber!);
+    const { setValue, watch } = useFormContext<ItemSchema>();
+    useEffect(() => {
+        const currentIsUnique = watch('uniqueSerialNumber');
+        console.log(currentIsUnique);
+        setValue('uniqueSerialNumber', currentIsUnique ? !!isUnique : false);
+    }, [isUnique]);
 
     if (isPlainText) {
         return <EllipsisText>{serialNumber}</EllipsisText>;

--- a/src/components/AddItemFormFields/SerialNumber/SerialNumber.tsx
+++ b/src/components/AddItemFormFields/SerialNumber/SerialNumber.tsx
@@ -28,7 +28,6 @@ export const SerialNumber = ({ serialNumber, onChange, isPlainText }: SerialNumb
     const { setValue, watch } = useFormContext<ItemSchema>();
     useEffect(() => {
         const currentIsUnique = watch('uniqueSerialNumber');
-        console.log(currentIsUnique);
         setValue('uniqueSerialNumber', currentIsUnique ? !!isUnique : false);
     }, [isUnique]);
 

--- a/src/components/AddItemFormFields/SerialNumbers/SerialNumbers.tsx
+++ b/src/components/AddItemFormFields/SerialNumbers/SerialNumbers.tsx
@@ -18,6 +18,7 @@ export const SerialNumbers = () => {
     const {
         field: { value, onChange },
     } = useController({ name: 'serialNumber', control });
+
     const [oldSerialNumber, setOldSerialNumber] = useState(value);
     const [serialNumbers, setSerialNumber] = useState(value);
 
@@ -26,9 +27,11 @@ export const SerialNumbers = () => {
         setSerialNumber(oldSerialNumber);
     };
     const handleChange = (newValue: string, index: number) => {
-        const newValues = [...value];
-        newValues[index] = newValue;
-        setSerialNumber(newValues);
+        setSerialNumber((prev) => {
+            const newValues = [...prev];
+            newValues[index] = newValue;
+            return newValues;
+        });
     };
 
     const handleSave = () => {
@@ -36,6 +39,7 @@ export const SerialNumbers = () => {
         setOldSerialNumber(serialNumbers);
         setIsOpen((prev) => !prev);
     };
+
     return (
         <>
             <div>
@@ -47,7 +51,7 @@ export const SerialNumbers = () => {
                         <Edit onClick={() => setIsOpen((prev) => !prev)} />
                     </StyledIconContainer>
                     <ErrorMessage
-                        name={`serialNumber[0]`}
+                        name={`serialNumber`}
                         as="span"
                         render={({ message }) => <StyledErrorP>{message}</StyledErrorP>}
                     />

--- a/src/components/AddItemFormFields/WpId/WpId.tsx
+++ b/src/components/AddItemFormFields/WpId/WpId.tsx
@@ -1,7 +1,10 @@
 import { ErrorMessage } from '@hookform/error-message';
 import HelpOutlineIcon from '@mui/icons-material/HelpOutline';
 import { TextField } from '@mui/material';
+import { useEffect } from 'react';
+import { useFormContext } from 'react-hook-form';
 import { useDebounce } from 'usehooks-ts';
+import { ItemSchema } from '../../../pages/addItem/hooks/itemValidator';
 import { useIsWpIdUnique } from '../../../services/hooks/items/useIsWpIdUnique';
 import { ToolTip } from '../../ToolTip/ToolTip';
 import { EllipsisText, StyledDiv, StyledErrorP, StyledInputWrap } from '../styles';
@@ -15,11 +18,17 @@ type WpIdProps = {
 
 export const WpId = ({ wpId, onChange, isPlainText }: WpIdProps) => {
     const debouncedWpId = useDebounce(wpId, 500);
-    const { data: isUnique, isLoading } = useIsWpIdUnique(debouncedWpId);
+    const { data: isUnique = true, isLoading } = useIsWpIdUnique(debouncedWpId);
+    const { setValue, watch } = useFormContext<ItemSchema>();
 
     if (isPlainText) {
         return <EllipsisText>{wpId}</EllipsisText>;
     }
+
+    useEffect(() => {
+        const currentIsUnique = watch('uniqueWpId');
+        setValue('uniqueWpId', currentIsUnique ? !!isUnique : false);
+    }, [isUnique]);
 
     return (
         <>

--- a/src/components/AddItemFormFields/WpId/WpId.tsx
+++ b/src/components/AddItemFormFields/WpId/WpId.tsx
@@ -21,14 +21,14 @@ export const WpId = ({ wpId, onChange, isPlainText }: WpIdProps) => {
     const { data: isUnique = true, isLoading } = useIsWpIdUnique(debouncedWpId);
     const { setValue, watch } = useFormContext<ItemSchema>();
 
-    if (isPlainText) {
-        return <EllipsisText>{wpId}</EllipsisText>;
-    }
-
     useEffect(() => {
         const currentIsUnique = watch('uniqueWpId');
         setValue('uniqueWpId', currentIsUnique ? !!isUnique : false);
     }, [isUnique]);
+
+    if (isPlainText) {
+        return <EllipsisText>{wpId}</EllipsisText>;
+    }
 
     return (
         <>

--- a/src/components/AddItemFormFields/WpIds/WpIds.tsx
+++ b/src/components/AddItemFormFields/WpIds/WpIds.tsx
@@ -15,7 +15,7 @@ import {
 
 export const WpIds = () => {
     const [isOpen, setIsOpen] = useState(false);
-    const { control } = useFormContext<ItemSchema>();
+    const { control, setValue } = useFormContext<ItemSchema>();
     const {
         field: { value, onChange },
     } = useController({ name: 'wpId', control });
@@ -26,10 +26,13 @@ export const WpIds = () => {
         setIsOpen((prev) => !prev);
         setWpIds(oldWpIds);
     };
+
     const handleChange = (newValue: string, index: number) => {
-        const newValues = [...value];
-        newValues[index] = newValue;
-        setWpIds(newValues);
+        setWpIds((prev) => {
+            const newValues = [...prev];
+            newValues[index] = newValue;
+            return newValues;
+        });
     };
 
     const handleSave = () => {
@@ -37,6 +40,7 @@ export const WpIds = () => {
         setOldWpIds(wpIds);
         setIsOpen((prev) => !prev);
     };
+
     return (
         <>
             <div>
@@ -48,7 +52,7 @@ export const WpIds = () => {
                         <Edit onClick={() => setIsOpen((prev) => !prev)} />
                     </StyledIconContainer>
                     <ErrorMessage
-                        name={`wpId[0]`}
+                        name={`wpId`}
                         as="span"
                         render={({ message }) => <StyledErrorP>{message}</StyledErrorP>}
                     />
@@ -58,7 +62,7 @@ export const WpIds = () => {
                     {wpIds.map((wpId, index) => {
                         return (
                             <WpId
-                                key={wpId}
+                                key={index}
                                 wpId={wpId}
                                 isPlainText
                                 onChange={(value) => handleChange(value, index)}

--- a/src/components/AddItemFormFields/WpIds/WpIds.tsx
+++ b/src/components/AddItemFormFields/WpIds/WpIds.tsx
@@ -15,7 +15,7 @@ import {
 
 export const WpIds = () => {
     const [isOpen, setIsOpen] = useState(false);
-    const { control, setValue } = useFormContext<ItemSchema>();
+    const { control } = useFormContext<ItemSchema>();
     const {
         field: { value, onChange },
     } = useController({ name: 'wpId', control });

--- a/src/components/Upload/AddItemUpload.tsx
+++ b/src/components/Upload/AddItemUpload.tsx
@@ -44,7 +44,11 @@ export const AddItemUpload = () => {
             </Box>
 
             <Box sx={{ display: 'flex', justifyContent: 'end' }}>
-                <SubmitButton variant="white" onClick={() => inputFile.current?.click()}>
+                <SubmitButton
+                    variant="white"
+                    type="button"
+                    onClick={() => inputFile.current?.click()}
+                >
                     <input
                         type="file"
                         multiple

--- a/src/components/Upload/UploadMobile/AddItemUploadMobile.tsx
+++ b/src/components/Upload/UploadMobile/AddItemUploadMobile.tsx
@@ -73,7 +73,11 @@ export const AddItemUploadMobile = () => {
                 )}
             </Wrapper>
             <Box sx={{ display: 'flex', justifyContent: 'end' }}>
-                <SubmitButton variant="white" onClick={() => inputFile.current?.click()}>
+                <SubmitButton
+                    variant="white"
+                    type="button"
+                    onClick={() => inputFile.current?.click()}
+                >
                     <input
                         type="file"
                         multiple

--- a/src/pages/addItem/batch/BatchForm.tsx
+++ b/src/pages/addItem/batch/BatchForm.tsx
@@ -6,7 +6,7 @@ import { useBatchForm } from './hooks/useBatchForm.tsx';
 import { RadioWrapper, StyledInput } from './styles.ts';
 
 export const BatchForm = () => {
-    const { isBatch, onChangeIsBatch, numberOfItemsField, error } = useBatchForm();
+    const { isBatch, onChangeIsBatch, numberOfItemsField } = useBatchForm();
     return (
         <FormContainer>
             {/* <h3>Add as a batch?</h3>

--- a/src/pages/addItem/batch/BatchForm.tsx
+++ b/src/pages/addItem/batch/BatchForm.tsx
@@ -9,7 +9,7 @@ export const BatchForm = () => {
     const { isBatch, onChangeIsBatch, numberOfItemsField, error } = useBatchForm();
     return (
         <FormContainer>
-            <h3>Add as a batch?</h3>
+            {/* <h3>Add as a batch?</h3>
             <span style={{ color: 'red' }}>{error?.message}</span>
 
             <label>
@@ -22,7 +22,7 @@ export const BatchForm = () => {
                     />
                     <p>I want to add one unique item</p>
                 </RadioWrapper>
-            </label>
+            </label> */}
             <label>
                 <RadioWrapper>
                     <StyledInput
@@ -53,7 +53,7 @@ export const BatchForm = () => {
                         size="small"
                         style={{ width: '80px' }}
                         InputProps={{ sx: { borderRadius: 0 } }}
-                        inputProps={{ min: 1 }}
+                        inputProps={{ min: 0 }}
                         placeholder="number of items"
                     />
                 </div>

--- a/src/pages/addItem/batch/hooks/useBatchForm.tsx
+++ b/src/pages/addItem/batch/hooks/useBatchForm.tsx
@@ -20,10 +20,12 @@ export const useBatchForm = () => {
     });
     const handleOnNumberOfChangeItems = (e: ChangeEvent<HTMLTextAreaElement>) => {
         onChangeNumberOfItems(e.target.value);
+
         const uniqueWpIds = Array.from({ length: +e.target.value }, () => uuid().slice(0, 8));
         const uniqueSerialNumbers = Array.from({ length: +e.target.value }, () =>
             uuid().slice(0, 8)
         );
+
         setValue('wpId', uniqueWpIds);
         setValue('serialNumber', uniqueSerialNumbers);
     };

--- a/src/pages/addItem/hooks/itemValidator.ts
+++ b/src/pages/addItem/hooks/itemValidator.ts
@@ -20,8 +20,28 @@ const templateSchema = z.object({
 export const itemSchema = z.object({
     itemTemplate: templateSchema,
     itemTemplateId: z.string(),
-    wpId: z.array(z.string().min(1, 'WpId is required')).min(1),
-    serialNumber: z.array(z.string().min(1, 'Serial number is required')).min(1),
+    wpId: z
+        .array(z.string().min(1, 'WpId is required'))
+        .min(1)
+        .refine(
+            (data) => {
+                return new Set(data).size === data.length;
+            },
+            {
+                message: 'All ids must be unique',
+            }
+        ),
+    serialNumber: z
+        .array(z.string().min(1, 'Serial number is required'))
+        .min(1)
+        .refine(
+            (data) => {
+                return new Set(data).size === data.length;
+            },
+            {
+                message: 'All ids must be unique',
+            }
+        ),
     vendorId: z.string().min(1, 'Vendor is required'),
     comment: z.string().nullish(),
     isBatch: z.boolean(),

--- a/src/pages/addItem/hooks/useAddItemForm.ts
+++ b/src/pages/addItem/hooks/useAddItemForm.ts
@@ -27,8 +27,8 @@ const defaultValues: ItemSchema = {
     itemTemplateId: '',
     comment: '',
     createdById: '',
-    uniqueWpId: false,
-    uniqueSerialNumber: false,
+    uniqueWpId: true,
+    uniqueSerialNumber: true,
     isBatch: false,
     preCheck: { check: false, comment: '' },
     documentation: false,
@@ -87,7 +87,6 @@ export const useAddItemForm = () => {
         });
         return data.json() as Promise<ItemTemplate>;
     };
-
     const onSubmit = handleSubmit(
         async (data) => {
             if (!selectedTemplate.id) {

--- a/src/pages/itemDetails/itemInfo/ItemInfo.tsx
+++ b/src/pages/itemDetails/itemInfo/ItemInfo.tsx
@@ -91,6 +91,7 @@ export const ItemInfo = ({ item, isLoading }: ItemInfoProps) => {
                         {
                             ...itemTemplateData,
                             [field]: mutableValue,
+                            revision: '1.0',
                         },
                         {
                             onSuccess: (data) => {


### PR DESCRIPTION
## Pull Request Summary

### What is missing from the codebase?

Currently, the uniqueWPIds and uniqueSerialNumber did not register correctly, as the value was not changed at the correct time. SerialNumbers  and WpIds were also reset to previous state if the user writes in value and then selects and writes an value into the other input. 
also, when users were allowed to write in identical values without any errors showing. 
### Changes made in this pull request:

- uniqueWPids and uniqueSerialNumbers has correct function that checks Isunique and setValue to uniqueWPids/serialnumber is false/true
- fixed key to index 
- fixed state reset issue
- added validation to zod that requires WpIds and serialNumbers to be unique, and displaying error.
- added revision to be '1'

## Checklist

-   [x] **Review**: Have you reviewed your own changes to ensure they align with best practices?
