### PR TITLE
359 fix item cards

### DIFF
--- a/src/components/ItemCard/ItemCard.tsx
+++ b/src/components/ItemCard/ItemCard.tsx
@@ -1,12 +1,11 @@
 import { useLocation, useNavigate } from 'react-router-dom';
 import { ItemTemplate, Location, Vendor } from '../../services/apiTypes';
 import { SearchInfo } from './SearchInfo/SearchInfo';
-import { StyledItemCardContainer, StyledSearchCard } from './styles';
+import { StyledSearchCard } from './styles';
 
 export type ItemCardProps = {
     item: {
         id: string;
-
         wpId: string;
         serialNumber: string;
         location?: Location;
@@ -33,10 +32,8 @@ export const ItemCard = ({ item, icon }: ItemCardProps) => {
             : undefined;
 
     return (
-        <StyledItemCardContainer style={{ cursor: cursorStyle }} onClick={handleClick}>
-            <StyledSearchCard title="">
-                <SearchInfo item={item} icon={icon} />
-            </StyledSearchCard>
-        </StyledItemCardContainer>
+        <StyledSearchCard title="" onClick={handleClick} style={{ cursor: cursorStyle }}>
+            <SearchInfo item={item} icon={icon} />
+        </StyledSearchCard>
     );
 };

--- a/src/components/ItemCard/SearchInfoCompact/SearchInfoCompact.tsx
+++ b/src/components/ItemCard/SearchInfoCompact/SearchInfoCompact.tsx
@@ -20,6 +20,7 @@ import {
     StyledCompactTitle,
     StyledItemCardCompactContainer,
 } from './styles';
+import { COLORS } from '../../../style/GlobalStyles';
 
 export const SearchResultCardCompact = ({ item, icon }: ItemCardProps) => {
     const navigate = useNavigate();
@@ -41,6 +42,7 @@ export const SearchResultCardCompact = ({ item, icon }: ItemCardProps) => {
                     style={{
                         boxShadow: 'none',
                         borderRadius: '0px',
+                        background: COLORS.lightestGray,
                     }}
                 >
                     <AccordionSummary

--- a/src/components/ItemCard/SearchInfoCompact/styles.ts
+++ b/src/components/ItemCard/SearchInfoCompact/styles.ts
@@ -1,14 +1,10 @@
 import { styled } from 'styled-components';
-import { COLORS } from '../../../style/GlobalStyles';
 
 export const StyledItemCardCompactContainer = styled.div`
     display: flex;
-    /* background-color: ${COLORS.lightGray}; */
-    background-color: orange;
     margin: 16px;
     box-shadow: 2px 4px 4px 0 rgba(0, 0, 0, 0.2);
     flex-direction: column;
-    max-width: 400px;
     position: relative;
 `;
 

--- a/src/components/ItemCard/SearchInfoCompact/styles.ts
+++ b/src/components/ItemCard/SearchInfoCompact/styles.ts
@@ -2,7 +2,6 @@ import { styled } from 'styled-components';
 
 export const StyledItemCardCompactContainer = styled.div`
     display: flex;
-    margin-bottom: 16px;
     box-shadow: 2px 4px 4px 0 rgba(0, 0, 0, 0.2);
     flex-direction: column;
     position: relative;

--- a/src/components/ItemCard/SearchInfoCompact/styles.ts
+++ b/src/components/ItemCard/SearchInfoCompact/styles.ts
@@ -2,7 +2,7 @@ import { styled } from 'styled-components';
 
 export const StyledItemCardCompactContainer = styled.div`
     display: flex;
-    margin: 16px;
+    margin-bottom: 16px;
     box-shadow: 2px 4px 4px 0 rgba(0, 0, 0, 0.2);
     flex-direction: column;
     position: relative;

--- a/src/components/ItemCard/styles.ts
+++ b/src/components/ItemCard/styles.ts
@@ -1,13 +1,12 @@
 import { styled } from 'styled-components';
 import { COLORS } from '../../style/GlobalStyles';
 
-export const StyledItemCardContainer = styled.div`
-    width: 550px;
-    margin-inline: auto;
-`;
-
 export const StyledSearchCard = styled.div`
     position: relative;
     background: ${COLORS.lightestGray};
     box-shadow: 2px 4px 4px 0 rgba(0, 0, 0, 0.2);
+
+    &:hover {
+        background: ${COLORS.lightGray};
+    }
 `;

--- a/src/components/ResultSearchCard/ResultSearchCard.tsx
+++ b/src/components/ResultSearchCard/ResultSearchCard.tsx
@@ -2,7 +2,7 @@ import { useNavigate } from 'react-router-dom';
 import { Item } from '../../services/apiTypes';
 
 import { SearchInfo } from '../ItemCard/SearchInfo/SearchInfo';
-import { StyledItemCardContainer, StyledSearchCard } from '../ItemCard/styles';
+import { StyledSearchCard } from '../ItemCard/styles';
 
 type Props = {
     item: Item;
@@ -14,7 +14,8 @@ export const SearchResultCard = ({ item, icon }: Props) => {
 
     return (
         <>
-            <StyledItemCardContainer
+            <StyledSearchCard
+                title=""
                 style={{
                     cursor: `${location.pathname.includes(`/makelist`) ? null : `pointer`}`,
                 }}
@@ -22,10 +23,8 @@ export const SearchResultCard = ({ item, icon }: Props) => {
                     location.pathname.includes('/makelist') ? null : navigate(`/item/${item.id}`);
                 }}
             >
-                <StyledSearchCard title="">
-                    <SearchInfo item={item} icon={icon} />
-                </StyledSearchCard>
-            </StyledItemCardContainer>
+                <SearchInfo item={item} icon={icon} />
+            </StyledSearchCard>
         </>
     );
 };

--- a/src/pages/addItem/recentlyAdded/styles.ts
+++ b/src/pages/addItem/recentlyAdded/styles.ts
@@ -20,9 +20,4 @@ export const CardContainer = styled.div`
     flex-direction: column;
     padding: 16px;
     gap: 16px;
-
-    @media (max-width: 800px) {
-        gap: 0px;
-        margin: 0px;
-    }
 `;

--- a/src/pages/addItem/recentlyAdded/styles.ts
+++ b/src/pages/addItem/recentlyAdded/styles.ts
@@ -18,7 +18,7 @@ export const Container = styled.div`
 export const CardContainer = styled.div`
     display: flex;
     flex-direction: column;
-    margin: 32px;
+    padding: 16px;
     gap: 16px;
 
     @media (max-width: 800px) {

--- a/src/pages/search/styles.ts
+++ b/src/pages/search/styles.ts
@@ -21,13 +21,8 @@ export const LoadMoreButton = styled.button`
 export const Container = styled.div`
     display: flex;
     flex-direction: column;
-    margin: 32px;
     gap: 16px;
-
-    @media (max-width: 800px) {
-        gap: 0px;
-        margin: 0px;
-    }
+    margin-top: 16px;
 `;
 
 export const RecentSearchContainer = styled.div`


### PR DESCRIPTION
## Pull Request Summary

### What is missing from the codebase?

Currently, the item cards are in the center of page

### Changes made in this pull request:

- item cards now fill the whole space
- background color to phone item cards
- removed unnecessary div

## Checklist

-   [x] **Review**: Have you reviewed your own changes to ensure they align with best practices?
