### PR TITLE
refactor: adjust size of description on item card

### DIFF
--- a/src/components/AdminSearchCard/styles.ts
+++ b/src/components/AdminSearchCard/styles.ts
@@ -30,15 +30,15 @@ export const StyledEllipsisContainer = styled.div`
     }
 
     @media screen and (max-width: 700px) {
-        width: 400px;
+        width: 380px;
     }
 
     @media screen and (max-width: 570px) {
-        width: 250px;
+        width: 210px;
     }
 
     @media screen and (max-width: 400px) {
-        width: 200px;
+        width: 175px;
     }
 `;
 

--- a/src/components/ItemCard/SearchInfo/styles.ts
+++ b/src/components/ItemCard/SearchInfo/styles.ts
@@ -27,7 +27,7 @@ export const StyledBox = styled.div`
     justify-content: space-between;
     margin: 16px;
     gap: 16px;
-    width: 100%;
+    width: 30%;
 `;
 
 export const StyledContent = styled.div`

--- a/src/pages/admin/styles.ts
+++ b/src/pages/admin/styles.ts
@@ -5,6 +5,7 @@ export const AdminContainer = styled.div`
     display: flex;
     flex-direction: column;
     padding: 16px;
+    gap: 16px;
 `;
 
 export const SearchResultContainer = styled.div`


### PR DESCRIPTION
## Pull Request Summary

### What is missing from the codebase?

Currently, the width of the content in item card is wrong 

### Changes made in this pull request:

- made it so the description takes 70% width of the card
- added some spacing between admin cards and search bar
- adjusted the media query so action buttons dont over flow on admin card

## Checklist

-   [x] **Review**: Have you reviewed your own changes to ensure they align with best practices?
