### PR TITLE
feat

### DIFF
--- a/src/components/CustomNumberInput/CustomNumberInput.tsx
+++ b/src/components/CustomNumberInput/CustomNumberInput.tsx
@@ -1,0 +1,44 @@
+import {
+    Unstable_NumberInput as BaseNumberInput,
+    NumberInputProps,
+} from '@mui/base/Unstable_NumberInput';
+import AddIcon from '@mui/icons-material/Add';
+import RemoveIcon from '@mui/icons-material/Remove';
+import * as React from 'react';
+import { useBatchForm } from '../../pages/addItem/batch/hooks/useBatchForm';
+import { StyledButton, StyledInput, StyledInputRoot } from './styles';
+
+const NumberInput = React.forwardRef(function CustomNumberInput(
+    props: NumberInputProps,
+    ref: React.ForwardedRef<HTMLDivElement>
+) {
+    const { numberOfItemsField } = useBatchForm();
+
+    return (
+        <BaseNumberInput
+            slots={{
+                root: StyledInputRoot,
+                input: StyledInput,
+                incrementButton: StyledButton,
+                decrementButton: StyledButton,
+            }}
+            slotProps={{
+                incrementButton: {
+                    children: <AddIcon fontSize="small" />,
+                    className: 'increment',
+                },
+                decrementButton: {
+                    children: <RemoveIcon fontSize="small" />,
+                },
+            }}
+            {...props}
+            onChange={numberOfItemsField.onChange}
+            value={+numberOfItemsField.value}
+            ref={ref}
+        />
+    );
+});
+
+export default function CustomNumberInput() {
+    return <NumberInput aria-label="Quantity Input" min={1} max={200} />;
+}

--- a/src/components/CustomNumberInput/styles.tsx
+++ b/src/components/CustomNumberInput/styles.tsx
@@ -60,9 +60,9 @@ export const StyledButton = styled('button')<InputProps>(
   line-height: 1.5;
   border: 1px solid;
   border-radius: 999px;
-  border-color: ${(theme.palette?.mode as string) === 'dark' ? grey[800] : grey[200]};
-  background: ${(theme.palette?.mode as string) === 'dark' ? grey[900] : grey[50]};
-  color: ${(theme.palette?.mode as string) === 'dark' ? grey[200] : grey[900]};
+  border-color: ${theme.palette?.mode === 'dark' ? grey[800] : grey[200]};
+  background: ${theme.palette?.mode === 'dark' ? grey[900] : grey[50]};
+  color: ${theme.palette?.mode === 'dark' ? grey[200] : grey[900]};
   width: 32px;
   height: 32px;
   display: flex;
@@ -75,8 +75,8 @@ export const StyledButton = styled('button')<InputProps>(
 
   &:hover {
     cursor: pointer;
-    background: ${(theme.palette?.mode as string) === 'dark' ? blue[700] : blue[500]};
-    border-color: ${(theme.palette?.mode as string) === 'dark' ? blue[500] : blue[400]};
+    background: ${theme.palette?.mode === 'dark' ? blue[700] : blue[500]};
+    border-color: ${theme.palette?.mode === 'dark' ? blue[500] : blue[400]};
     color: ${grey[50]};
   }
 

--- a/src/components/CustomNumberInput/styles.tsx
+++ b/src/components/CustomNumberInput/styles.tsx
@@ -1,5 +1,5 @@
+import { styled } from '@mui/material';
 import { blue, grey } from '@mui/material/colors';
-import styled from 'styled-components';
 
 type InputProps = {
     theme: string | undefined;
@@ -8,7 +8,7 @@ export const StyledInputRoot = styled('div')<InputProps>(
     ({ theme }) => `
   font-family: 'IBM Plex Sans', sans-serif;
   font-weight: 400;
-  color: ${theme?.palette?.mode === 'dark' ? grey[300] : grey[500]};
+  color: ${theme.palette.mode === 'dark' ? grey[300] : grey[500]};
   display: flex;
 gap: 20px;
   flex-flow: row nowrap;

--- a/src/components/CustomNumberInput/styles.tsx
+++ b/src/components/CustomNumberInput/styles.tsx
@@ -1,0 +1,111 @@
+import styled from 'styled-components';
+
+export const blue = {
+    100: '#daecff',
+    200: '#b6daff',
+    300: '#66b2ff',
+    400: '#3399ff',
+    500: '#007fff',
+    600: '#0072e5',
+    700: '#0059B2',
+    800: '#004c99',
+};
+
+export const grey = {
+    50: '#F3F6F9',
+    100: '#E5EAF2',
+    200: '#DAE2ED',
+    300: '#C7D0DD',
+    400: '#B0B8C4',
+    500: '#9DA8B7',
+    600: '#6B7A90',
+    700: '#434D5B',
+    800: '#303740',
+    900: '#1C2025',
+};
+
+export const StyledInputRoot = styled('div')(
+    ({ theme }) => `
+  font-family: 'IBM Plex Sans', sans-serif;
+  font-weight: 400;
+  color: ${theme?.palette?.mode === 'dark' ? grey[300] : grey[500]};
+  display: flex;
+gap: 20px;
+  flex-flow: row nowrap;
+  justify-content: center;
+  align-items: center;
+`
+);
+
+export const StyledInput = styled('input')(
+    ({ theme }) => `
+  font-size: 0.875rem;
+  font-family: inherit;
+  font-weight: 400;
+  line-height: 1.375;
+  color: ${theme.palette?.mode === 'dark' ? grey[300] : grey[900]};
+  background: ${theme.palette?.mode === 'dark' ? grey[900] : '#fff'};
+  border: 1px solid ${theme.palette?.mode === 'dark' ? grey[700] : grey[200]};
+  box-shadow: 0px 2px 4px ${
+      theme.palette?.mode === 'dark' ? 'rgba(0,0,0, 0.5)' : 'rgba(0,0,0, 0.05)'
+  };
+  border-radius: 8px;
+  margin: 0 8px;
+  padding: 10px 12px;
+  outline: 0;
+  min-width: 0;
+  width: 4rem;
+  text-align: center;
+
+  &:hover {
+    border-color: ${blue[400]};
+  }
+
+  &:focus {
+    border-color: ${blue[400]};
+    box-shadow: 0 0 0 3px ${theme.palette?.mode === 'dark' ? blue[700] : blue[200]};
+  }
+
+  &:focus-visible {
+    outline: 0;
+  }
+`
+);
+
+export const StyledButton = styled('button')(
+    ({ theme }) => `
+  font-family: 'IBM Plex Sans', sans-serif;
+  font-size: 0.875rem;
+  box-sizing: border-box;
+  line-height: 1.5;
+  border: 1px solid;
+  border-radius: 999px;
+  border-color: ${theme.palette?.mode === 'dark' ? grey[800] : grey[200]};
+  background: ${theme.palette?.mode === 'dark' ? grey[900] : grey[50]};
+  color: ${theme.palette?.mode === 'dark' ? grey[200] : grey[900]};
+  width: 32px;
+  height: 32px;
+  display: flex;
+  flex-flow: row nowrap;
+  justify-content: center;
+  align-items: center;
+  transition-property: all;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-duration: 120ms;
+
+  &:hover {
+    cursor: pointer;
+    background: ${theme.palette?.mode === 'dark' ? blue[700] : blue[500]};
+    border-color: ${theme.palette?.mode === 'dark' ? blue[500] : blue[400]};
+    color: ${grey[50]};
+  }
+
+  &:focus-visible {
+    outline: 0;
+  }
+
+  &.increment {
+    order: 1;
+  }
+`
+);

--- a/src/components/CustomNumberInput/styles.tsx
+++ b/src/components/CustomNumberInput/styles.tsx
@@ -1,30 +1,10 @@
+import { blue, grey } from '@mui/material/colors';
 import styled from 'styled-components';
 
-export const blue = {
-    100: '#daecff',
-    200: '#b6daff',
-    300: '#66b2ff',
-    400: '#3399ff',
-    500: '#007fff',
-    600: '#0072e5',
-    700: '#0059B2',
-    800: '#004c99',
+type InputProps = {
+    theme: string | undefined;
 };
-
-export const grey = {
-    50: '#F3F6F9',
-    100: '#E5EAF2',
-    200: '#DAE2ED',
-    300: '#C7D0DD',
-    400: '#B0B8C4',
-    500: '#9DA8B7',
-    600: '#6B7A90',
-    700: '#434D5B',
-    800: '#303740',
-    900: '#1C2025',
-};
-
-export const StyledInputRoot = styled('div')(
+export const StyledInputRoot = styled('div')<InputProps>(
     ({ theme }) => `
   font-family: 'IBM Plex Sans', sans-serif;
   font-weight: 400;
@@ -37,7 +17,7 @@ gap: 20px;
 `
 );
 
-export const StyledInput = styled('input')(
+export const StyledInput = styled('input')<InputProps>(
     ({ theme }) => `
   font-size: 0.875rem;
   font-family: inherit;
@@ -72,7 +52,7 @@ export const StyledInput = styled('input')(
 `
 );
 
-export const StyledButton = styled('button')(
+export const StyledButton = styled('button')<InputProps>(
     ({ theme }) => `
   font-family: 'IBM Plex Sans', sans-serif;
   font-size: 0.875rem;
@@ -80,9 +60,9 @@ export const StyledButton = styled('button')(
   line-height: 1.5;
   border: 1px solid;
   border-radius: 999px;
-  border-color: ${theme.palette?.mode === 'dark' ? grey[800] : grey[200]};
-  background: ${theme.palette?.mode === 'dark' ? grey[900] : grey[50]};
-  color: ${theme.palette?.mode === 'dark' ? grey[200] : grey[900]};
+  border-color: ${(theme.palette?.mode as string) === 'dark' ? grey[800] : grey[200]};
+  background: ${(theme.palette?.mode as string) === 'dark' ? grey[900] : grey[50]};
+  color: ${(theme.palette?.mode as string) === 'dark' ? grey[200] : grey[900]};
   width: 32px;
   height: 32px;
   display: flex;
@@ -95,8 +75,8 @@ export const StyledButton = styled('button')(
 
   &:hover {
     cursor: pointer;
-    background: ${theme.palette?.mode === 'dark' ? blue[700] : blue[500]};
-    border-color: ${theme.palette?.mode === 'dark' ? blue[500] : blue[400]};
+    background: ${(theme.palette?.mode as string) === 'dark' ? blue[700] : blue[500]};
+    border-color: ${(theme.palette?.mode as string) === 'dark' ? blue[500] : blue[400]};
     color: ${grey[50]};
   }
 

--- a/src/pages/addItem/batch/BatchForm.tsx
+++ b/src/pages/addItem/batch/BatchForm.tsx
@@ -1,63 +1,27 @@
 import { ErrorMessage } from '@hookform/error-message';
-import { TextField } from '@mui/material';
+import { useFormContext } from 'react-hook-form';
 import { StyledErrorP } from '../../../components/AddItemFormFields/styles.ts';
-import { FormContainer } from '../styles.ts';
-import { useBatchForm } from './hooks/useBatchForm.tsx';
-import { RadioWrapper, StyledInput } from './styles.ts';
+import CustomNumberInput from '../../../components/CustomNumberInput/CustomNumberInput.tsx';
+import { ItemSchema } from '../hooks/itemValidator.ts';
+import { FormContainer, StyledLabelText } from '../styles.ts';
+import { StyledBatchWrapper } from './styles.ts';
 
 export const BatchForm = () => {
-    const { isBatch, onChangeIsBatch, numberOfItemsField } = useBatchForm();
+    const { watch } = useFormContext<ItemSchema>();
+
     return (
         <FormContainer>
-            {/* <h3>Add as a batch?</h3>
-            <span style={{ color: 'red' }}>{error?.message}</span>
+            <StyledBatchWrapper>
+                <h3>Batch</h3>
+                <StyledLabelText> number of items</StyledLabelText>
 
-            <label>
-                <RadioWrapper>
-                    <StyledInput
-                        checked={!isBatch}
-                        type="radio"
-                        name="batchCheck"
-                        onChange={() => onChangeIsBatch(false)}
-                    />
-                    <p>I want to add one unique item</p>
-                </RadioWrapper>
-            </label> */}
-            <label>
-                <RadioWrapper>
-                    <StyledInput
-                        checked={isBatch}
-                        type="radio"
-                        name="batchCheck"
-                        onChange={() => onChangeIsBatch(true)}
-                    />
-                    <p>
-                        I want to add a batch of several identical items, assigning a unique
-                        WellPartner serial number to each of them
-                    </p>
-                </RadioWrapper>
-            </label>
-            {numberOfItemsField.value && (
-                <div style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
-                    <label>
-                        <strong>Number of items:</strong>
-                    </label>
-                    <ErrorMessage
-                        name="emptyAmount"
-                        render={({ message }) => <StyledErrorP>{message}</StyledErrorP>}
-                    />
-                    <TextField
-                        {...numberOfItemsField}
-                        type="number"
-                        label="Amount"
-                        size="small"
-                        style={{ width: '80px' }}
-                        InputProps={{ sx: { borderRadius: 0 } }}
-                        inputProps={{ min: 0 }}
-                        placeholder="number of items"
-                    />
-                </div>
-            )}
+                <CustomNumberInput />
+
+                <ErrorMessage
+                    name="numberOfItems"
+                    render={({ message }) => <StyledErrorP>{message}</StyledErrorP>}
+                />
+            </StyledBatchWrapper>
         </FormContainer>
     );
 };

--- a/src/pages/addItem/batch/BatchForm.tsx
+++ b/src/pages/addItem/batch/BatchForm.tsx
@@ -1,14 +1,10 @@
 import { ErrorMessage } from '@hookform/error-message';
-import { useFormContext } from 'react-hook-form';
 import { StyledErrorP } from '../../../components/AddItemFormFields/styles.ts';
 import CustomNumberInput from '../../../components/CustomNumberInput/CustomNumberInput.tsx';
-import { ItemSchema } from '../hooks/itemValidator.ts';
 import { FormContainer, StyledLabelText } from '../styles.ts';
 import { StyledBatchWrapper } from './styles.ts';
 
 export const BatchForm = () => {
-    const { watch } = useFormContext<ItemSchema>();
-
     return (
         <FormContainer>
             <StyledBatchWrapper>

--- a/src/pages/addItem/batch/hooks/useBatchForm.tsx
+++ b/src/pages/addItem/batch/hooks/useBatchForm.tsx
@@ -1,4 +1,3 @@
-import { ChangeEvent } from 'react';
 import { useController, useFormContext } from 'react-hook-form';
 import { v4 as uuid } from 'uuid';
 import { ItemSchema } from '../../hooks/itemValidator';
@@ -18,13 +17,17 @@ export const useBatchForm = () => {
         control,
         name: 'numberOfItems',
     });
-    const handleOnNumberOfChangeItems = (e: ChangeEvent<HTMLTextAreaElement>) => {
-        onChangeNumberOfItems(e.target.value);
+    const handleOnNumberOfChangeItems = (
+        _event: React.FocusEvent<HTMLInputElement> | React.PointerEvent | React.KeyboardEvent,
+        value = 0
+    ) => {
+        onChangeNumberOfItems(value);
 
-        const uniqueWpIds = Array.from({ length: +e.target.value }, () => uuid().slice(0, 8));
-        const uniqueSerialNumbers = Array.from({ length: +e.target.value }, () =>
-            uuid().slice(0, 8)
-        );
+        const isBatch = value > 1;
+        setValue('isBatch', !!isBatch);
+
+        const uniqueWpIds = Array.from({ length: value }, () => uuid().slice(0, 8));
+        const uniqueSerialNumbers = Array.from({ length: value }, () => uuid().slice(0, 8));
 
         setValue('wpId', uniqueWpIds);
         setValue('serialNumber', uniqueSerialNumbers);
@@ -32,7 +35,6 @@ export const useBatchForm = () => {
 
     return {
         isBatch: value,
-        onChangeIsBatch: onChange,
         numberOfItemsField: {
             onChange: handleOnNumberOfChangeItems,
             ...rest,

--- a/src/pages/addItem/batch/hooks/useBatchForm.tsx
+++ b/src/pages/addItem/batch/hooks/useBatchForm.tsx
@@ -5,7 +5,7 @@ import { ItemSchema } from '../../hooks/itemValidator';
 export const useBatchForm = () => {
     const { control, setValue } = useFormContext<ItemSchema>();
     const {
-        field: { onChange, value },
+        field: { value },
         fieldState: { error },
     } = useController({
         control,

--- a/src/pages/addItem/batch/styles.ts
+++ b/src/pages/addItem/batch/styles.ts
@@ -33,3 +33,12 @@ export const RadioWrapper = styled.div`
     display: flex;
     width: fit-content;
 `;
+
+export const StyledBatchWrapper = styled.div`
+    display: flex;
+
+    flex-direction: column;
+    gap: 10px;
+    align-items: first baseline;
+    justify-content: baseline;
+`;

--- a/src/pages/addItem/batch/styles.ts
+++ b/src/pages/addItem/batch/styles.ts
@@ -36,7 +36,6 @@ export const RadioWrapper = styled.div`
 
 export const StyledBatchWrapper = styled.div`
     display: flex;
-
     flex-direction: column;
     gap: 10px;
     align-items: first baseline;

--- a/src/pages/addItem/check/CheckForm.tsx
+++ b/src/pages/addItem/check/CheckForm.tsx
@@ -1,8 +1,8 @@
 import { useController, useFormContext } from 'react-hook-form';
 import { RadioWrapper, StyledInput } from '../batch/styles';
 import { ItemSchema } from '../hooks/itemValidator';
-import { FormContainer } from '../styles';
-import { StyledLabelText, StyledTextArea } from './styles';
+import { FormContainer, StyledLabelText } from '../styles';
+import { StyledTextArea } from './styles';
 
 export const CheckForm = () => {
     const { control, register } = useFormContext<ItemSchema>();

--- a/src/pages/addItem/check/styles.ts
+++ b/src/pages/addItem/check/styles.ts
@@ -38,9 +38,3 @@ export const FormRadio = styled.form`
         cursor: pointer;
     }
 `;
-export const StyledLabelText = styled.p`
-    font-weight: 600;
-    display: inline;
-    margin: 20px 0;
-    margin-left: 10px;
-`;

--- a/src/pages/addItem/hooks/itemValidator.ts
+++ b/src/pages/addItem/hooks/itemValidator.ts
@@ -67,7 +67,7 @@ export const itemSchema = z.object({
     uniqueWpId: z.boolean().refine((data) => data, {}),
     uniqueSerialNumber: z.boolean().refine((data) => data, {}),
     files: z.array(z.instanceof(File)).nullish(),
-    numberOfItems: z.string(),
+    numberOfItems: z.number().min(1, 'minimum one item').max(200, 'max 200 items'),
 });
 
 export type ItemSchema = z.infer<typeof itemSchema>;

--- a/src/pages/addItem/hooks/useAddItemForm.ts
+++ b/src/pages/addItem/hooks/useAddItemForm.ts
@@ -76,7 +76,7 @@ export const useAddItemForm = () => {
             setValue('itemTemplate.revision', selectedTemplate.revision || '');
         }
     }, []);
-    console.log(watch());
+
     const templateSubmit = async () => {
         const data = await templateMutate({
             categoryId: selectedTemplate.categoryId || '',

--- a/src/pages/addItem/hooks/useAddItemForm.ts
+++ b/src/pages/addItem/hooks/useAddItemForm.ts
@@ -2,6 +2,7 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { useContext, useEffect } from 'react';
 import { useForm } from 'react-hook-form';
 import { useLocation } from 'react-router-dom';
+import { v4 as uuid } from 'uuid';
 import AppContext from '../../../contexts/AppContext';
 import { ItemTemplate } from '../../../services/apiTypes';
 import { useAddItems } from '../../../services/hooks/items/useAddItem';
@@ -20,8 +21,8 @@ const defaultTemplate: TemplateSchema = {
 };
 
 const defaultValues: ItemSchema = {
-    wpId: [],
-    serialNumber: [],
+    wpId: [uuid().slice(0, 8)],
+    serialNumber: [uuid().slice(0, 8)],
     vendorId: '',
     locationId: '',
     itemTemplateId: '',
@@ -33,7 +34,7 @@ const defaultValues: ItemSchema = {
     preCheck: { check: false, comment: '' },
     documentation: false,
     itemTemplate: defaultTemplate,
-    numberOfItems: '1',
+    numberOfItems: 1,
 };
 
 export const useAddItemForm = () => {
@@ -75,7 +76,7 @@ export const useAddItemForm = () => {
             setValue('itemTemplate.revision', selectedTemplate.revision || '');
         }
     }, []);
-
+    console.log(watch());
     const templateSubmit = async () => {
         const data = await templateMutate({
             categoryId: selectedTemplate.categoryId || '',
@@ -99,7 +100,7 @@ export const useAddItemForm = () => {
                     description,
                 } = await templateSubmit();
 
-                const numberOfItems = parseInt(data.numberOfItems);
+                const numberOfItems = data.numberOfItems;
                 const items: ItemSchema[] = [];
                 for (let i = 0; i < numberOfItems; i++) {
                     items.push({
@@ -134,7 +135,7 @@ export const useAddItemForm = () => {
                     }
                 );
             } else {
-                const numberOfItems = parseInt(data.numberOfItems);
+                const numberOfItems = data.numberOfItems;
                 const items: ItemSchema[] = [];
                 for (let i = 0; i < numberOfItems; i++) {
                     items.push({

--- a/src/pages/addItem/styles.ts
+++ b/src/pages/addItem/styles.ts
@@ -41,3 +41,9 @@ export const ButtonWrapper = styled.div`
         height: 2rem;
     }
 `;
+export const StyledLabelText = styled.p`
+    font-weight: 600;
+    display: inline;
+    margin: 20px 0;
+    margin-left: 10px;
+`;


### PR DESCRIPTION
## Pull Request Summary

### What is missing from the codebase?

- Currently, the Batch had two radio buttons asking if the user want to add 1 item`(batch:false) `or more `(batch:true)`, however, batch can just be controlled by the result of the value being more than 1, so only a number input field is required.



- Currently, _WpIds_ and _SerialNumbers_ would not display their unique ids if the number of items from the batch page was only '1', 

- Currently, used **Textfield**` type=numbers `has been used for Batch page, but due to Mui adivcing agianst the use, it has been replaced by **NumberInput**, as recommended by Mui.
- 
>  ![fdsfds](https://github.com/OptiCorp/inventory-app/assets/112854862/b09381a0-5667-4404-b7a7-b5040aa7ff2b)


### Changes made in this pull request:

- Removed Radiobuttons , leaving the number input field to control the IsBatch
- Replaced **TextField** with **CustomNumberInput**
- Changed '_numberOfItems_' to numbers from string in both validator and formhandler, _with `min(1) and max(200). 
`
> max number cbe discussed further

- added **CustomNumberInput** to component folder
- made _WpIds_ and _SerialNumber_ default value be uuid unique id, so it will also be displayed if only 1 item is being added.

## Checklist

-   [x] **Review**: Have you reviewed your own changes to ensure they align with best practices?
