### PR TITLE
fix

### DIFF
--- a/src/components/File/File.tsx
+++ b/src/components/File/File.tsx
@@ -5,7 +5,7 @@ import {
     StyledFileWrapper,
     StyledIconWrapper,
 } from './style';
-import { Button as MuiButton, Tooltip } from '@mui/material';
+import { Button as MuiButton } from '@mui/material';
 import DeleteOutlineOutlinedIcon from '@mui/icons-material/DeleteOutlineOutlined';
 import FileDownloadOutlinedIcon from '@mui/icons-material/FileDownloadOutlined';
 import { Document } from '../../services/apiTypes';
@@ -14,10 +14,9 @@ type FileProps = {
     doc?: Document;
     file?: File;
     handleFileRemoval: () => void;
-    downloadButton?: boolean;
 };
 
-export const File = ({ doc, file, handleFileRemoval, downloadButton }: FileProps) => {
+export const File = ({ doc, file, handleFileRemoval }: FileProps) => {
     const handleFileDownload = (doc?: Document, file?: File) => {
         if (file) {
             const downloadLink = document.createElement('a');
@@ -27,70 +26,54 @@ export const File = ({ doc, file, handleFileRemoval, downloadButton }: FileProps
         }
         if (doc) {
             const downloadLink = document.createElement('a');
-            downloadLink.download = `${fileName}`;
+            downloadLink.download = `${doc.name}`;
             downloadLink.href = `data:${doc.contentType};base64,${doc.bytes}`;
             downloadLink.click();
         }
     };
 
-    const maxLength = 14;
-    const fileName = doc?.fileName ? doc.fileName : doc?.name;
-
     return (
-        <Tooltip title={fileName}>
-            <StyledFileWrapper className="files">
-                <svg
-                    xmlns="http://www.w3.org/2000/svg"
-                    width="121"
-                    height="153"
-                    viewBox="0 0 121 153"
-                    fill="none"
-                >
-                    <foreignObject width={121} height={153}>
-                        <StyledFileShapeWrapper>
-                            <StyledFileTypeWrapper>
-                                <h3>
-                                    .
-                                    {doc
-                                        ? doc.contentType.split('/')[1].toUpperCase()
-                                        : file?.type.split('/')[1].toUpperCase()}
-                                </h3>
-                            </StyledFileTypeWrapper>
-                            <StyledIconWrapper>
-                                {downloadButton && (
-                                    <MuiButton
-                                        onClick={
-                                            doc
-                                                ? () => handleFileDownload(doc)
-                                                : () => handleFileDownload(undefined, file)
-                                        }
-                                        sx={{ color: 'black' }}
-                                    >
-                                        <FileDownloadOutlinedIcon fontSize="large" />
-                                    </MuiButton>
-                                )}
-                                <MuiButton
-                                    onClick={handleFileRemoval}
-                                    sx={{ color: 'black', marginLeft: 'auto' }}
-                                >
-                                    <DeleteOutlineOutlinedIcon fontSize="large" />
-                                </MuiButton>
-                            </StyledIconWrapper>
-                        </StyledFileShapeWrapper>
-                    </foreignObject>
-                    <path
-                        d="M95 1H1V152H120V21.1333M95 1L120 21.1333M95 1V21.1333H120"
-                        stroke="black"
-                    />
-                </svg>
-                <StyledDocumentName>
-                    {doc?.fileName
-                        ? doc.fileName.length > maxLength
-                            ? `${doc.fileName.substring(0, maxLength)}...`
-                            : doc.fileName
-                        : doc?.name}
-                </StyledDocumentName>
-            </StyledFileWrapper>
-        </Tooltip>
+        <StyledFileWrapper className="files">
+            <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="121"
+                height="153"
+                viewBox="0 0 121 153"
+                fill="none"
+            >
+                <foreignObject width={121} height={153}>
+                    <StyledFileShapeWrapper>
+                        <StyledFileTypeWrapper>
+                            <h3>
+                                .
+                                {doc
+                                    ? doc.contentType.split('/')[1].toUpperCase()
+                                    : file?.type.split('/')[1].toUpperCase()}
+                            </h3>
+                        </StyledFileTypeWrapper>
+                        <StyledIconWrapper>
+                            <MuiButton
+                                onClick={
+                                    doc
+                                        ? () => handleFileDownload(doc)
+                                        : () => handleFileDownload(undefined, file)
+                                }
+                                sx={{ color: 'black' }}
+                            >
+                                <FileDownloadOutlinedIcon fontSize="large" />
+                            </MuiButton>
+                            <MuiButton onClick={handleFileRemoval} sx={{ color: 'black' }}>
+                                <DeleteOutlineOutlinedIcon fontSize="large" />
+                            </MuiButton>
+                        </StyledIconWrapper>
+                    </StyledFileShapeWrapper>
+                </foreignObject>
+                <path
+                    d="M95 1H1V152H120V21.1333M95 1L120 21.1333M95 1V21.1333H120"
+                    stroke="black"
+                />
+            </svg>
+            <StyledDocumentName>{doc ? doc.name.split('.')[0] : file?.name}</StyledDocumentName>
+        </StyledFileWrapper>
     );
 };

--- a/src/components/File/File.tsx
+++ b/src/components/File/File.tsx
@@ -1,3 +1,7 @@
+import DeleteOutlineOutlinedIcon from '@mui/icons-material/DeleteOutlineOutlined';
+import FileDownloadOutlinedIcon from '@mui/icons-material/FileDownloadOutlined';
+import { Button as MuiButton } from '@mui/material';
+import { Document } from '../../services/apiTypes';
 import {
     StyledDocumentName,
     StyledFileShapeWrapper,
@@ -5,10 +9,6 @@ import {
     StyledFileWrapper,
     StyledIconWrapper,
 } from './style';
-import { Button as MuiButton } from '@mui/material';
-import DeleteOutlineOutlinedIcon from '@mui/icons-material/DeleteOutlineOutlined';
-import FileDownloadOutlinedIcon from '@mui/icons-material/FileDownloadOutlined';
-import { Document } from '../../services/apiTypes';
 
 type FileProps = {
     doc?: Document;
@@ -62,7 +62,11 @@ export const File = ({ doc, file, handleFileRemoval }: FileProps) => {
                             >
                                 <FileDownloadOutlinedIcon fontSize="large" />
                             </MuiButton>
-                            <MuiButton onClick={handleFileRemoval} sx={{ color: 'black' }}>
+
+                            <MuiButton
+                                onClick={handleFileRemoval}
+                                sx={{ color: 'black', marginLeft: 'auto' }}
+                            >
                                 <DeleteOutlineOutlinedIcon fontSize="large" />
                             </MuiButton>
                         </StyledIconWrapper>

--- a/src/components/ItemCard/SearchInfo/styles.ts
+++ b/src/components/ItemCard/SearchInfo/styles.ts
@@ -27,7 +27,7 @@ export const StyledBox = styled.div`
     justify-content: space-between;
     margin: 16px;
     gap: 16px;
-    width: 30%;
+    width: 100%;
 `;
 
 export const StyledContent = styled.div`

--- a/src/components/ItemCard/SearchInfoCompact/SearchInfoCompact.tsx
+++ b/src/components/ItemCard/SearchInfoCompact/SearchInfoCompact.tsx
@@ -7,6 +7,7 @@ import {
     Button,
 } from '@mui/material';
 import { NavLink, useNavigate, useParams } from 'react-router-dom';
+import { COLORS } from '../../../style/GlobalStyles';
 import { CustomDialog } from '../../CustomDialog/CustomDialog';
 import { StyledAddIcon, StyledRemoveIcon } from '../../ListCard/styles';
 import { ItemCardProps } from '../ItemCard';
@@ -20,7 +21,6 @@ import {
     StyledCompactTitle,
     StyledItemCardCompactContainer,
 } from './styles';
-import { COLORS } from '../../../style/GlobalStyles';
 
 export const SearchResultCardCompact = ({ item, icon }: ItemCardProps) => {
     const navigate = useNavigate();

--- a/src/components/ItemCard/SearchInfoCompact/styles.ts
+++ b/src/components/ItemCard/SearchInfoCompact/styles.ts
@@ -2,7 +2,8 @@ import { styled } from 'styled-components';
 
 export const StyledItemCardCompactContainer = styled.div`
     display: flex;
-    box-shadow: 2px 4px 4px 0 rgba(0, 0, 0, 0.2);
+    box-shadow: 3px 2px 3px 0 rgba(0, 0, 0, 0.2);
+
     flex-direction: column;
     position: relative;
 `;
@@ -58,5 +59,6 @@ export const StyledCompactBox = styled.div`
     display: flex;
     justify-content: space-between;
     width: 100%;
+    box-shadow: none;
     margin: 10px 0;
 `;

--- a/src/components/Upload/Upload.tsx
+++ b/src/components/Upload/Upload.tsx
@@ -20,8 +20,8 @@ import { useGetDocumentTypes } from '../../services/hooks/documents/useGetDocume
 import { useGetDocumentsByItemId } from '../../services/hooks/documents/useGetDocumentsByItemId';
 import { useUploadDocumentToItem } from '../../services/hooks/documents/useUploadDocumentToItem';
 import { COLORS } from '../../style/GlobalStyles';
-import { File } from '../File/File';
 import { CustomDialog } from '../CustomDialog/CustomDialog';
+import { File } from '../File/File';
 
 type UploadProps = {
     itemId: string;
@@ -160,7 +160,6 @@ export const ExampleUpload = ({ itemId }: UploadProps) => {
                                         document?.fileName ? document.fileName : document.name
                                     )
                                 }
-                                downloadButton={true}
                             />
                         );
                     })

--- a/src/components/Upload/UploadMobile/UploadMobile.tsx
+++ b/src/components/Upload/UploadMobile/UploadMobile.tsx
@@ -1,26 +1,26 @@
 import ArrowCircleRightOutlinedIcon from '@mui/icons-material/ArrowCircleRightOutlined';
-import FileUploadIcon from '@mui/icons-material/FileUpload';
 import CloseIcon from '@mui/icons-material/Close';
+import FileUploadIcon from '@mui/icons-material/FileUpload';
 import {
+    Button,
     Dialog,
     DialogContent,
     DialogTitle,
     FormControlLabel,
     List,
     ListItem,
-    Button,
     Radio,
     RadioGroup,
 } from '@mui/material';
 import { useEffect, useRef, useState } from 'react';
 import { AddDocument } from '../../../services/apiTypes';
 import { useDeleteDocument } from '../../../services/hooks/documents/useDeleteDocument';
-import { useGetDocumentsByItemId } from '../../../services/hooks/documents/useGetDocumentsByItemId';
-import { Container, Wrapper } from './styles';
-import { Button as SubmitButton } from '../../Button/Button';
-import { useUploadDocumentToItem } from '../../../services/hooks/documents/useUploadDocumentToItem';
 import { useGetDocumentTypes } from '../../../services/hooks/documents/useGetDocumentTypes';
+import { useGetDocumentsByItemId } from '../../../services/hooks/documents/useGetDocumentsByItemId';
+import { useUploadDocumentToItem } from '../../../services/hooks/documents/useUploadDocumentToItem';
+import { Button as SubmitButton } from '../../Button/Button';
 import { File } from '../../File/File';
+import { Container, Wrapper } from './styles';
 
 type UploadProps = {
     itemId: string;
@@ -143,7 +143,6 @@ export const UploadMobile = ({ itemId }: UploadProps) => {
                         key={document.id}
                         doc={document}
                         handleFileRemoval={() => handleFileDelete(document.id)}
-                        downloadButton={true}
                     />
                 ))}
                 {showArrow === true && (documents?.length ?? 0) > 2 && (

--- a/src/pages/itemDetails/Index.tsx
+++ b/src/pages/itemDetails/Index.tsx
@@ -83,12 +83,6 @@ export const ItemDetails = () => {
             <ButtonContainer>
                 <Button
                     variant="outlined"
-                    onClick={() => navigate(`/item/${id}/template/${item.itemTemplateId}`)}
-                >
-                    Edit template
-                </Button>
-                <Button
-                    variant="outlined"
                     color="error"
                     sx={{ borderRadius: '0', height: '40px', width: '200px' }}
                     onClick={() => setIsOpen(true)}

--- a/src/pages/itemDetails/TemplateInfo.tsx
+++ b/src/pages/itemDetails/TemplateInfo.tsx
@@ -1,18 +1,18 @@
-import { useParams } from 'react-router-dom';
-import { useGetItemTemplateById } from '../../services/hooks/template/useGetItemTemplateById';
-import { SelectField } from './itemInfo/SelectField';
-import { useGetCategories } from '../../services/hooks/category/useGetCategories';
-import { useFormContext } from 'react-hook-form';
-import { ItemInfoSchema } from './itemInfo/hooks';
-import { useGetItemById } from '../../services/hooks/items/useGetItemById';
-import { handleApiRequestSnackbar } from '../../utils/handleApiRequestSnackbar';
-import { useUpdateItemTemplate } from '../../services/hooks/template/useUpdateItemTemplate';
 import { useContext } from 'react';
+import { useFormContext } from 'react-hook-form';
+import { useParams } from 'react-router-dom';
 import AppContext from '../../contexts/AppContext';
-import { Container, CreatedByContainer, ItemInfoForm } from './itemInfo/styles';
-import { EditableField } from './itemInfo/EditableField';
-import { Types } from './itemInfo/types';
 import { Item } from '../../services/apiTypes';
+import { useGetCategories } from '../../services/hooks/category/useGetCategories';
+import { useGetItemById } from '../../services/hooks/items/useGetItemById';
+import { useGetItemTemplateById } from '../../services/hooks/template/useGetItemTemplateById';
+import { useUpdateItemTemplate } from '../../services/hooks/template/useUpdateItemTemplate';
+import { handleApiRequestSnackbar } from '../../utils/handleApiRequestSnackbar';
+import { EditableField } from './itemInfo/EditableField';
+import { SelectField } from './itemInfo/SelectField';
+import { ItemInfoSchema } from './itemInfo/hooks';
+import { Container, CreatedByContainer, ItemInfoForm } from './itemInfo/styles';
+import { Types } from './itemInfo/types';
 const typesOptions: Types[] = [
     { id: 'Unit', name: 'Unit' },
     { id: 'Assembly', name: 'Assembly' },
@@ -72,6 +72,21 @@ export const TemplateInfo = () => {
                                     setSnackbarSeverity,
                                     setSnackbarText
                                 );
+
+                                if (itemTemplateData.revision.length === 0) {
+                                    setSnackbarSeverity('error');
+                                    setSnackbarText(
+                                        `${data.statusText}, revision can not be empty.`
+                                    );
+                                }
+                                if (data.status >= 400) {
+                                    setSnackbarSeverity('error');
+                                    setSnackbarText(
+                                        itemTemplateData.revision.length >= 2
+                                            ? 'revision must be at least 3 characters.'
+                                            : `${data.statusText}, please try again.`
+                                    );
+                                }
                             },
                         }
                     );
@@ -118,7 +133,7 @@ export const TemplateInfo = () => {
                 />
                 <EditableField
                     fieldName="REVISION"
-                    label="itemTemplate.revision"
+                    label={'itemTemplate.revision'}
                     onBlur={() =>
                         handleBlurItemTemplateProperties(
                             'revision',

--- a/src/pages/itemDetails/itemInfo/EditableField.tsx
+++ b/src/pages/itemDetails/itemInfo/EditableField.tsx
@@ -1,7 +1,8 @@
 import { Box, ClickAwayListener } from '@mui/material';
-import { Controller, useFormContext } from 'react-hook-form';
 import { ChangeEvent, ComponentProps, useState } from 'react';
-import { FieldNames } from './types';
+import { Controller, useFormContext } from 'react-hook-form';
+import { COLORS } from '../../../style/GlobalStyles';
+import { ItemInfoSchema } from './hooks';
 import {
     Edit,
     ErrorP,
@@ -10,7 +11,7 @@ import {
     StyledTextField,
     TextBoxWrap,
 } from './styles';
-import { ItemInfoSchema } from './hooks';
+import { FieldNames } from './types';
 
 type EditableFieldProps<TMultiLine = boolean> = {
     fieldName: FieldNames;
@@ -91,21 +92,34 @@ export const EditableField = ({
                                             InputProps={{
                                                 disableUnderline: !open,
                                                 readOnly: !open,
+                                                style: {
+                                                    color:
+                                                        isEmpty && !open ? COLORS.red : undefined,
+                                                    fontWeight:
+                                                        isEmpty && !open ? '600' : undefined,
+                                                },
                                             }}
                                             onBlur={onBlur}
                                             onChange={fieldOnChange}
                                             multiline={isMultiLine}
                                             fullWidth
+                                            value={
+                                                isEmpty && !open
+                                                    ? `${name
+                                                          .replace('itemTemplate.', '')
+                                                          .toLowerCase()} can not be empty`
+                                                    : value
+                                            }
                                             rows={rows}
                                         />
                                     </InfoContainer>
                                     {loading && <p>Checking...</p>}
-                                    {isEmpty && (
+                                    {/* {isEmpty && (
                                         <ErrorP>
                                             {name.replace('itemTemplate.', '').toLowerCase()} can
                                             not be empty.
                                         </ErrorP>
-                                    )}
+                                    )} */}
                                     {isUnique === false && (
                                         <ErrorP>{name.toLowerCase()} must be unique</ErrorP>
                                     )}

--- a/src/pages/itemDetails/itemInfo/ItemInfo.tsx
+++ b/src/pages/itemDetails/itemInfo/ItemInfo.tsx
@@ -1,6 +1,8 @@
 import { useContext, useEffect, useState } from 'react';
 import { useFormContext } from 'react-hook-form';
 
+import { Tooltip } from '@mui/material';
+import { useNavigate } from 'react-router-dom';
 import { useDebounce } from 'usehooks-ts';
 import { GlobalSpinner } from '../../../components/GlobalSpinner/GlobalSpinner';
 import AppContext from '../../../contexts/AppContext';
@@ -10,16 +12,13 @@ import { useIsWpIdUnique } from '../../../services/hooks/items/useIsWpIdUnique';
 import { useUpdateItem } from '../../../services/hooks/items/useUpdateItem';
 import { useGetLocations } from '../../../services/hooks/locations/useGetLocations';
 import { useGetVendors } from '../../../services/hooks/vendor/useGetVendors';
+import { FlexColumn } from '../../../style/GlobalStyles';
 import { handleApiRequestSnackbar } from '../../../utils/handleApiRequestSnackbar';
 import { EditableField } from './EditableField';
 import { SelectField } from './SelectField';
 import { ItemInfoSchema } from './hooks';
-import { Container, CreatedByContainer, ItemInfoForm } from './styles';
+import { Container, CreatedByContainer, Edit, ItemInfoForm, LabelContainer } from './styles';
 import { Types } from './types';
-import { useNavigate } from 'react-router-dom';
-import { Edit, LabelContainer } from './styles';
-import { Tooltip } from '@mui/material';
-import { FlexColumn } from '../../../style/GlobalStyles';
 
 type ItemInfoProps = {
     item: Item;

--- a/src/pages/itemDetails/itemInfo/SelectField.tsx
+++ b/src/pages/itemDetails/itemInfo/SelectField.tsx
@@ -49,7 +49,7 @@ export const SelectField = ({ label, onBlur, options, placeholder, fieldName }: 
             }),
             menu: (provided: CSSObjectWithLabel) => ({
                 ...provided,
-                width: '70%',
+                width: '100%',
                 maxWidth: '500px',
             }),
             option: (

--- a/src/pages/listDetails/phone/list/styles.ts
+++ b/src/pages/listDetails/phone/list/styles.ts
@@ -15,5 +15,9 @@ export const ListContainerCompact = styled.div`
     overflow: auto;
     padding-bottom: 100px;
     display: flex;
+
+    gap: 10px;
+    padding-right: 10px;
+    padding-left: 10px;
     flex-direction: column;
 `;

--- a/src/style/GlobalStyles.ts
+++ b/src/style/GlobalStyles.ts
@@ -95,6 +95,7 @@ export default GlobalStyles;
 
 export const FlexColumn = styled.div`
     display: flex;
+    gap: 10px;
     flex-direction: column;
 `;
 


### PR DESCRIPTION
## Pull Request Summary

### What is missing from the codebase?

Currently, we had to ways of getting to the template edit page, and there was nothing that alerted the user that Revision had to be more than 3 charecters to go through the backend, the error message for Revision was also weirdly placed with the revision field being empty

### Changes made in this pull request:

- removed Edit Template Button at the bottom
- added snackbar message alert if users try to change anything else without adding revision
- added snackbar message if Revision is empty or less than 3 charecters
- styling fixes

## Checklist

-   [x] **Review**: Have you reviewed your own changes to ensure they align with best practices?
